### PR TITLE
Add null check for generateTags content type

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -86,7 +86,10 @@ exports.generateTags = functions.storage.object().onFinalize(async (object) => {
     const filePath = object.name;
     const contentType = object.contentType;
 
-    if (!contentType.startsWith("image/")) {
+    if (!contentType || !contentType.startsWith("image/")) {
+        if (!contentType) {
+            functions.logger.log("Content type is missing for file:", filePath);
+        }
         return functions.logger.log("This is not an image.");
     }
 


### PR DESCRIPTION
## Summary
- handle missing or non-image content types in `generateTags`
- log missing content types for easier debugging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad83d4cc832aa22bf0170a75348d