### PR TITLE
Restrict subscriber writes to authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,10 +3,12 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // Subscribers: Anyone can sign up, but no one can read the list.
+    // Subscribers: restrict writes to authenticated users.
+    // Consider handling sign-ups via a Cloud Function with validation,
+    // rate limiting, or CAPTCHA verification to deter abuse.
     match /subscribers/{subscriberId} {
       allow read: if false;
-      allow write: if true;
+      allow write: if request.auth != null;
     }
 
     // Races: Anyone can read the race schedule, only team members can change it.


### PR DESCRIPTION
## Summary
- tighten Firestore rules for `subscribers` so only authenticated users can write
- document Cloud Function, rate limiting, and CAPTCHA considerations to deter abuse

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1aef6ac50832a95fd7c5501333722