### PR TITLE
fix: Correct duplicate declaration of userRole on dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -605,7 +605,7 @@
                 await getRaceData();
 
                 const idTokenResult = await user.getIdTokenResult();
-                const userRole = idTokenResult.claims.role || 'public-fan';                console.log("User's custom claims:", idTokenResult.claims);
+                console.log("User's custom claims:", idTokenResult.claims);
                 const userRole = idTokenResult.claims.role;
 
                 if (userRole === 'team-member') {


### PR DESCRIPTION
This commit resolves a `SyntaxError: Identifier 'userRole' has already been declared` on the dashboard page. The error was caused by a duplicated `const userRole` line in the authentication script.

This change removes the redundant declaration, allowing the script to execute correctly.