### PR TITLE
chore(functions): Update firebase-functions to latest version

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@google-cloud/vision": "^4.0.2",
     "firebase-admin": "^12.0.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^6.4.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"


### PR DESCRIPTION
This commit updates the `firebase-functions` package from `^5.0.0` to `^6.4.0` to resolve the "outdated version" warning that appears during deployment.