### PR TITLE
Fix(JS): Standardize dropdown menu functionality

### DIFF
--- a/driver.html
+++ b/driver.html
@@ -134,6 +134,32 @@
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             // Mobile menu toggle
             document.getElementById('mobile-menu-button').addEventListener('click', () => {
                 document.getElementById('mobile-menu').classList.toggle('hidden');

--- a/gallery.html
+++ b/gallery.html
@@ -130,6 +130,32 @@
         import { getStorage, ref, uploadBytesResumable, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-storage.js";
 
         document.addEventListener('DOMContentLoaded', () => {
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             // Mobile menu toggle
             document.getElementById('mobile-menu-button').addEventListener('click', () => {
                 document.getElementById('mobile-menu').classList.toggle('hidden');

--- a/index.html
+++ b/index.html
@@ -139,6 +139,32 @@
                     content.classList.toggle('hidden');
                 });
             });
+
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
         });
     </script>
 </body>

--- a/jonny.html
+++ b/jonny.html
@@ -280,6 +280,32 @@
                 });
             });
 
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             document.getElementById('year').textContent = new Date().getFullYear();
         });
 

--- a/qna.html
+++ b/qna.html
@@ -121,6 +121,32 @@
         import { getFirestore, collection, addDoc, query, where, onSnapshot, orderBy, serverTimestamp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
         document.addEventListener('DOMContentLoaded', () => {
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             // Mobile menu toggle
             document.getElementById('mobile-menu-button').addEventListener('click', () => {
                 document.getElementById('mobile-menu').classList.toggle('hidden');

--- a/schedule.html
+++ b/schedule.html
@@ -124,6 +124,32 @@
         import { getFirestore, collection, query, onSnapshot, orderBy } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
         document.addEventListener('DOMContentLoaded', () => {
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             // Mobile menu toggle
             document.getElementById('mobile-menu-button').addEventListener('click', () => {
                 document.getElementById('mobile-menu').classList.toggle('hidden');

--- a/videos.html
+++ b/videos.html
@@ -115,6 +115,32 @@
     </footer>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
+            // Desktop dropdowns
+            document.querySelectorAll('.dropdown-toggle').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdownMenu = button.nextElementSibling;
+                    const isHidden = dropdownMenu.classList.contains('hidden');
+
+                    // Close all other dropdowns
+                    document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                        menu.classList.add('hidden');
+                    });
+
+                    // Toggle the current dropdown
+                    if (isHidden) {
+                        dropdownMenu.classList.remove('hidden');
+                    }
+                });
+            });
+
+            // Close dropdowns when clicking outside
+            window.addEventListener('click', () => {
+                document.querySelectorAll('.dropdown-menu').forEach(menu => {
+                    menu.classList.add('hidden');
+                });
+            });
+
             // Mobile menu toggle
             document.getElementById('mobile-menu-button').addEventListener('click', () => {
                 document.getElementById('mobile-menu').classList.toggle('hidden');


### PR DESCRIPTION
The desktop navigation dropdown menus were implemented with inconsistent JavaScript across different pages. Some pages used a simple toggle, while others had a more robust implementation that correctly handled closing other dropdowns when a new one was opened.

This change standardizes the dropdown functionality by applying the more robust logic from `index.html` to all other pages that use the dropdown navigation (`jonny.html`, `driver.html`, `gallery.html`, `qna.html`, `schedule.html`, `videos.html`).

This ensures a consistent user experience and improves code maintainability.