### PR TITLE
fix: Add hosting site to firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "site": "redsracing-a7f8b",
     "public": ".",
     "ignore": [
       "firebase.json",


### PR DESCRIPTION
This commit adds the explicit `site` configuration to the `hosting` section of `firebase.json`.

This is required to resolve the `Error: Hosting site or target hosting not detected in firebase.json` error that occurs during deployment.