### PR TITLE
Fix dashboard loading spinner visibility

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -864,7 +864,7 @@
                         <p class="text-sm text-slate-500 mt-4">Please try refreshing the page. If the problem persists, contact support.</p>
                     </div>`;
                 } finally {
-                    loadingState.classList.add('hidden');
+                    loadingState.style.display = 'none';
                     dashboardContent.classList.remove('hidden');
                 }
 


### PR DESCRIPTION
The loading spinner was still visible after the dashboard content had loaded due to a potential CSS class conflict.

This change modifies the code to hide the spinner by directly setting its `style.display` to `'none'`, which is more robust than adding a class. This ensures the spinner is always hidden correctly after the dashboard has finished its loading sequence.