### PR TITLE
fix(deps): correct mailgun package name in requirements.txt

### DIFF
--- a/functions_python/requirements.txt
+++ b/functions_python/requirements.txt
@@ -1,4 +1,4 @@
 firebase-functions==0.4.3
 firebase-admin==7.1.0
 flask>=3.1.2
-mailgun==1.1.0
+py-mailgun


### PR DESCRIPTION
The application was failing to deploy due to a ModuleNotFoundError for the 'mailgun' package. The import `from mailgun.client import Client` corresponds to the `py-mailgun` package, not the `mailgun` package.

This change replaces 'mailgun==1.1.0' with 'py-mailgun' in `functions_python/requirements.txt` to resolve the dependency issue.