### PR TITLE
fix: Implement profile backend and resolve loading spinner bug

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -647,8 +647,13 @@ import { ref, deleteObject } from "https://www.gstatic.com/firebasejs/11.6.1/fir
     }, 10000); // 10 second timeout
 
     function hideLoadingAndShowContent() {
-        loadingState.style.display = 'none';
-        dashboardContent.classList.remove('hidden');
+        if (loadingState) {
+            loadingState.style.display = 'none';
+            loadingState.setAttribute('hidden', 'true');
+        }
+        if (dashboardContent) {
+            dashboardContent.classList.remove('hidden');
+        }
         if (loadingTimeout) {
             clearTimeout(loadingTimeout);
             loadingTimeout = null;


### PR DESCRIPTION
This commit addresses two issues:
1.  The profile page was stuck in a loading state because it was trying to call backend endpoints that did not exist.
2.  The dashboard loading spinner would sometimes remain visible even after the page content had loaded.

The following changes have been made:
- Two new callable functions, `getProfile` and `updateProfile`, have been added to `functions/index.js` to provide the necessary backend logic for the profile page.
- The frontend `assets/js/profile.js` has been updated to use `httpsCallable` to interact with these new backend functions.
- The `hideLoadingAndShowContent` function in `assets/js/dashboard.js` has been made more robust to ensure the loading spinner is reliably hidden after the content loads.

These changes restore functionality to the profile page and fix the lingering loading spinner on the dashboard.