### PR TITLE
Fix(firestore): Remove unnecessary index for jonny_videos

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -110,16 +110,6 @@
         }
       ]
     },
-    {
-      "collectionGroup": "jonny_videos",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    }
   ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
Removes a redundant single-field index for the `jonny_videos` collection from `firestore.indexes.json`.

This index was causing a `HTTP Error: 400` during deployment because Firestore now creates single-field indexes automatically. This change resolves the deployment failure when running `firebase deploy --only firestore`.