### PR TITLE
Feat(email): Migrate from Mailgun to SendGrid

### DIFF
--- a/functions_python/requirements.txt
+++ b/functions_python/requirements.txt
@@ -1,4 +1,4 @@
 firebase-functions==0.4.3
 firebase-admin==7.1.0
 flask>=3.1.2
-mailgun==1.1.0
+sendgrid>=6.0.0


### PR DESCRIPTION
This commit replaces the Mailgun email provider with SendGrid for all email-sending functionality in the Python Cloud Functions.

Changes include:
- Updating `requirements.txt` to use the `sendgrid` package.
- Modifying `main.py` to use the SendGrid API and client.
- Changing the required secret from `MAILGUN_API_KEY` to `SENDGRID_API_KEY`.

The email functions `handleSendFeedback` and `handleSendSponsorship` have been rewritten to use the new provider.