### PR TITLE
Fix(project): Resolve deployment issues and migrate to SendGrid

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,43 +13,73 @@
     "rewrites": [
       {
         "source": "/add_subscriber",
-        "function": "handleAddSubscriber@python-api"
+        "function": {
+          "functionId": "handleAddSubscriber@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/send_feedback_email",
-        "function": "handleSendFeedback@python-api"
+        "function": {
+          "functionId": "handleSendFeedback@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/send_sponsorship_email",
-        "function": "handleSendSponsorship@python-api"
+        "function": {
+          "functionId": "handleSendSponsorship@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/profile/**",
-        "function": "handleGetProfile@python-api"
+        "function": {
+          "functionId": "handleGetProfile@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/update_profile/**",
-        "function": "handleUpdateProfile@python-api"
+        "function": {
+          "functionId": "handleUpdateProfile@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/achievements",
-        "function": "handleGetAchievements@python-api"
+        "function": {
+          "functionId": "handleGetAchievements@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/assign_achievement",
-        "function": "handleAssignAchievement@python-api"
+        "function": {
+          "functionId": "handleAssignAchievement@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/leaderboard",
-        "function": "handleGetLeaderboard@python-api"
+        "function": {
+          "functionId": "handleGetLeaderboard@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/auto_award_achievement",
-        "function": "handleAutoAwardAchievement@python-api"
+        "function": {
+          "functionId": "handleAutoAwardAchievement@python-api",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/achievement_progress/**",
-        "function": "handleGetAchievementProgress@python-api"
+        "function": {
+          "functionId": "handleGetAchievementProgress@python-api",
+          "region": "us-central1"
+        }
       }
     ]
   },


### PR DESCRIPTION
This commit includes a series of fixes to resolve multiple deployment and runtime errors, and completes the migration from Mailgun to SendGrid.

Changes:
- **`firebase.json`**: Explicitly defines the `us-central1` region for all function rewrites to resolve 'Unable to find endpoint' warnings during hosting deployment.
- **Email Service**: Migrates from Mailgun to SendGrid by updating `requirements.txt` and rewriting the email logic in `main.py`. The required secret is now `SENDGRID_API_KEY`.
- **Firestore Rules**: Corrects a permissions error by changing `allow read` to `allow get, list` for a collection query.
- **Firestore Indexes**: Removes a redundant single-field index from `firestore.indexes.json` that was causing deployment to fail.