### PR TITLE
Fix: Ensure correct Firebase initialization by mutating cache

### DIFF
--- a/assets/js/firebase-core.js
+++ b/assets/js/firebase-core.js
@@ -31,10 +31,16 @@ export async function initializeFirebaseCore() {
             });
             const storage = getStorage(app);
 
-            firebaseCache = { app, auth, db, storage, initialized: true, initPromise: null };
+            firebaseCache.app = app;
+            firebaseCache.auth = auth;
+            firebaseCache.db = db;
+            firebaseCache.storage = storage;
+            firebaseCache.initialized = true;
+            firebaseCache.initPromise = null;
+
             return firebaseCache;
         } catch (error) {
-            firebaseCache.initPromise = null;
+            firebaseCache.initPromise = null; // Also clear on failure
             throw error;
         }
     })();


### PR DESCRIPTION
This commit provides a definitive fix for a recurring 'Firebase not initialized' error.

The root cause was a subtle bug in `firebase-core.js` where the shared `firebaseCache` object was being reassigned instead of mutated within the `initializeFirebaseCore` function's promise. This could lead to a race condition where other functions would not see the `initialized: true` flag. The fix is to update the properties of the `firebaseCache` object directly, ensuring atomic and safe updates.

This commit also retains the previous changes that resolved the intermediate 'module does not provide an export' errors by refactoring `invitation-codes.js` and updating its call sites. These changes, while originally for a separate symptom, are necessary for the application to function correctly.