### PR TITLE
feat: Add global error handler for debugging

### DIFF
--- a/assets/js/global-error-handler.js
+++ b/assets/js/global-error-handler.js
@@ -1,0 +1,69 @@
+(function() {
+    function displayError(message, source, lineno, colno, error) {
+        // Prevent recursive errors
+        if (document.getElementById('global-error-overlay')) {
+            return;
+        }
+
+        const overlay = document.createElement('div');
+        overlay.id = 'global-error-overlay';
+        overlay.style.position = 'fixed';
+        overlay.style.top = '0';
+        overlay.style.left = '0';
+        overlay.style.width = '100%';
+        overlay.style.height = '100%';
+        overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
+        overlay.style.color = 'white';
+        overlay.style.zIndex = '999999';
+        overlay.style.padding = '20px';
+        overlay.style.fontFamily = 'monospace';
+        overlay.style.fontSize = '14px';
+        overlay.style.overflow = 'auto';
+
+        const errorBox = document.createElement('div');
+        errorBox.style.backgroundColor = '#330000';
+        errorBox.style.border = '2px solid red';
+        errorBox.style.borderRadius = '8px';
+        errorBox.style.padding = '20px';
+        errorBox.style.maxWidth = '800px';
+        errorBox.style.margin = 'auto';
+
+        let errorMessage = '<h2>A Critical Error Occurred</h2>';
+        errorMessage += '<p><strong>Message:</strong> ' + message + '</p>';
+        if (source) {
+            errorMessage += '<p><strong>Source:</strong> ' + source + ':' + lineno + ':' + colno + '</p>';
+        }
+        if (error && error.stack) {
+            errorMessage += '<p><strong>Stack Trace:</strong></p><pre>' + error.stack + '</pre>';
+        }
+
+        errorBox.innerHTML = errorMessage;
+        overlay.appendChild(errorBox);
+        document.body.appendChild(overlay);
+
+        // Also log to console
+        console.error("Global Error Handler Caught:", {
+            message: message,
+            source: source,
+            lineno: lineno,
+            colno: colno,
+            error: error
+        });
+    }
+
+    window.onerror = function(message, source, lineno, colno, error) {
+        displayError(message, source, lineno, colno, error);
+        return true; // Prevents the default browser error handling
+    };
+
+    window.addEventListener('unhandledrejection', function(event) {
+        let reason = event.reason;
+        if (reason instanceof Error) {
+            displayError(reason.message, reason.fileName || 'Promise', reason.lineNumber, reason.columnNumber, reason);
+        } else {
+            displayError(String(reason), 'Promise', null, null, null);
+        }
+    });
+
+    console.log('Global error handler initialized.');
+})();

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Driver Dashboard - RedsRacing #8</title>

--- a/driver.html
+++ b/driver.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Driver - RedsRacing #8</title>

--- a/feedback.html
+++ b/feedback.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Feedback - RedsRacing #8</title>

--- a/gallery.html
+++ b/gallery.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gallery - RedsRacing #8</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RedsRacing #8 - The Ultimate Hub</title>

--- a/jonny.html
+++ b/jonny.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jonny Kirsch - #88</title>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Leaderboard - RedsRacing #8</title>

--- a/login.html
+++ b/login.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - RedsRacing #8</title>

--- a/profile.html
+++ b/profile.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>User Profile - RedsRacing #8</title>

--- a/qna.html
+++ b/qna.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Q&A - RedsRacing #8</title>

--- a/schedule.html
+++ b/schedule.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Schedule - RedsRacing #8</title>

--- a/signup.html
+++ b/signup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign Up - RedsRacing #8</title>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sponsorship - RedsRacing #8</title>

--- a/videos.html
+++ b/videos.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Videos - RedsRacing #8</title>


### PR DESCRIPTION
This commit introduces a global error handler to catch and display all uncaught JavaScript errors and unhandled promise rejections. This is intended to help diagnose a persistent infinite loading issue by making any fatal script errors highly visible.

- Creates a new script `assets/js/global-error-handler.js`.
- The script sets up `window.onerror` and `unhandledrejection` listeners.
- When an error is caught, it displays the error message and stack trace in a full-screen overlay.
- The error handler script is added to the `<head>` of all HTML pages to ensure it loads first.