### PR TITLE
fix(dashboard): Increase loading timeout to prevent premature fallback

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -35,7 +35,7 @@ import { getFriendlyAuthError, isRecaptchaError } from './auth-errors.js';
 // Wrap everything in an async function to allow early returns
 (async function() {
     // Enhanced error handling and retry logic
-    const INITIAL_TIMEOUT = 15000; // Extended to 15 seconds to allow for retries
+    const INITIAL_TIMEOUT = 30000; // Extended to 30 seconds to allow for retries
     const MAX_RETRIES = 3;
     const RETRY_BASE_DELAY = 1000; // 1 second base delay for exponential backoff
     


### PR DESCRIPTION
The dashboard was configured with two loading timeouts that could create a race condition on slow connections:
1. An internal 15-second timeout in `dashboard.js` that would show a detailed error.
2. A 20-second fallback timer in `dashboard.html` that would show a generic "Dashboard Temporarily Unavailable" message.

If authentication and data loading took longer than 15 seconds, the internal timeout would fire, causing an error state even if the process was about to complete successfully.

This change increases the internal timeout in `dashboard.js` from 15 seconds to a more reasonable 30 seconds. This provides more buffer for slow network conditions and prevents the dashboard from showing a premature error message, improving the user experience for those on slower connections.