### PR TITLE
Fix: Prevent infinite loading on dashboard and profile

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -1136,9 +1136,8 @@ const updateRetryStatus = (attempt, maxAttempts, context) => {
 
     document.getElementById('year').textContent = new Date().getFullYear();
 
-    // Clear the loading timeout since we successfully initialized
-    clearLoadingTimeout();
-    console.log('[Dashboard:Complete] ✓ Dashboard initialization completed successfully');
+    // The loading timeout is now cleared only when content is shown or a fallback is triggered.
+    // console.log('[Dashboard:Complete] ✓ Dashboard initialization setup complete');
 
 
 })(); // End of async function wrapper

--- a/assets/js/profile.js
+++ b/assets/js/profile.js
@@ -1127,10 +1127,7 @@ import { getFriendlyAuthError, isRecaptchaError } from './auth-errors.js';
         hideLoadingAndShowFallback();
     }
 
-    // Clear the loading timeout since we successfully loaded
-    if (loadingTimeout) {
-        clearTimeout(loadingTimeout);
-        loadingTimeout = null;
-    }
+    // The loading timeout is now cleared only when content is shown or a fallback is triggered.
+    // console.log('[Profile] ✓ Profile initialization setup complete');
 
 })(); // End of async function wrapper


### PR DESCRIPTION
The dashboard and profile pages could get stuck on an infinite loading screen if the initial authentication process from Firebase was slow or failed silently.

This was caused by a race condition where a safety-net timeout, designed to show an error message after a delay, was being cleared prematurely at the end of the script's synchronous execution. This left no fallback if the asynchronous authentication listener never completed.

This commit fixes the issue by removing the premature `clearTimeout` calls from `dashboard.js` and `profile.js`. The timeout is now only cleared when the page content is successfully loaded and displayed, or when a fallback error UI is explicitly shown. This ensures the application remains responsive and provides user feedback even if backend services are slow.