### PR TITLE
Fix: Remove redundant Firestore index for 'races'

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -111,16 +111,6 @@
       ]
     },
     {
-      "collectionGroup": "races",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "date",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
       "collectionGroup": "jonny_videos",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
This commit removes an unnecessary single-field index definition for the 'races' collection from `firestore.indexes.json`.

This index was causing a `400 Bad Request` error during Firebase deployments with the message "this index is not necessary, configure using single field index controls". Firestore automatically creates single-field indexes, so manually defining them in `firestore.indexes.json` is redundant and causes deployment failures.

Removing this definition resolves the error and allows for successful deployments.