### PR TITLE
Fix: Remove unnecessary Firestore index for jonny_videos

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -110,16 +110,6 @@
         }
       ]
     },
-    {
-      "collectionGroup": "jonny_videos",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "createdAt",
-          "order": "DESCENDING"
-        }
-      ]
-    }
   ],
   "fieldOverrides": []
 }

--- a/tests/error_handling_test.html
+++ b/tests/error_handling_test.html
@@ -116,19 +116,18 @@
         }
 
         function checkFirestoreIndexes() {
-            // Mock test for index configuration 
+            // Mock test for index configuration to ensure unnecessary indexes are removed
             fetch('/firestore.indexes.json')
                 .then(response => response.json())
                 .then(data => {
                     const hasJonnyVideosIndex = data.indexes.some(index => 
-                        index.collectionGroup === 'jonny_videos' &&
-                        index.fields.some(field => field.fieldPath === 'createdAt' && field.order === 'DESCENDING')
+                        index.collectionGroup === 'jonny_videos'
                     );
                     
                     if (hasJonnyVideosIndex) {
-                        logResult('firestore-results', '✅ jonny_videos createdAt DESC index found in configuration', true);
+                        logResult('firestore-results', '❌ Unnecessary jonny_videos index found in configuration.', false);
                     } else {
-                        logResult('firestore-results', '❌ jonny_videos createdAt DESC index missing from configuration', false);
+                        logResult('firestore-results', '✅ Unnecessary jonny_videos index successfully removed.', true);
                     }
                 })
                 .catch(error => {


### PR DESCRIPTION
The single-field index for the `jonny_videos` collection was causing deployment errors because it is not necessary and Firestore can manage it automatically.

This change removes the index definition from `firestore.indexes.json` and updates the corresponding test in `tests/error_handling_test.html` to assert that the index is not present.