### PR TITLE
Fix: Define missing openRaceModal function in dashboard.js

### DIFF
--- a/assets/js/dashboard.js
+++ b/assets/js/dashboard.js
@@ -176,8 +176,39 @@ import { getFriendlyAuthError, isRecaptchaError } from './auth-errors.js';
         }, 1000);
     }
 
+    function openRaceModal(race = null) {
+        if (race) {
+            modalTitle.textContent = 'Edit Race';
+            raceIdInput.value = race.id || '';
+            raceDateInput.value = race.date || '';
+            raceNameInput.value = race.name || '';
+            raceTypeInput.value = race.type || 'standard';
+            raceResultsInput.value = race.results || '';
+            raceSummaryInput.value = race.summary || '';
+            liveTimingLinkInput.value = race.liveTimingLink || '';
+
+            if (race.type === 'special') {
+                raceNumberContainer.style.display = 'none';
+                specialNameContainer.style.display = 'block';
+                specialNameInput.value = race.specialName || '';
+            } else {
+                specialNameContainer.style.display = 'none';
+                raceNumberContainer.style.display = 'block';
+                raceNumberInput.value = race.raceNumber || '';
+            }
+        } else {
+            modalTitle.textContent = 'Add New Race';
+            raceForm.reset();
+            raceIdInput.value = '';
+            specialNameContainer.style.display = 'none';
+            raceNumberContainer.style.display = 'block';
+        }
+        raceModal.classList.remove('hidden');
+    }
+
     function renderRacesTable(races) {
         const tableBody = document.getElementById('races-table-body');
+        if (!tableBody) return;
         tableBody.innerHTML = '';
         races.forEach(race => {
             const row = document.createElement('tr');

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -109,7 +109,7 @@
           "order": "DESCENDING"
         }
       ]
-    },
+    }
   ],
   "fieldOverrides": []
 }


### PR DESCRIPTION
A critical error was occurring on the dashboard page because the `openRaceModal` function was being called but was not defined.

This change adds the definition of the `openRaceModal` function to `assets/js/dashboard.js`. The function handles both adding a new race and editing an existing one by populating a modal form.

This commit also includes a previous fix for an unrelated Firestore index issue.