### PR TITLE
Debug: Use direct URL for leaderboard fetch

### DIFF
--- a/assets/js/leaderboard.js
+++ b/assets/js/leaderboard.js
@@ -47,7 +47,7 @@ async function loadLeaderboard() {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
-    const response = await fetch('/leaderboard', {
+    const response = await fetch('https://handlegetleaderboard-r7f4oo4gjq-uc.a.run.app', {
       method: 'GET',
       signal: controller.signal,
       headers: {


### PR DESCRIPTION
This is a temporary commit for debugging purposes.

It changes the `fetch` call in `leaderboard.js` to use the direct URL of the `handlegetleaderboard` Cloud Function, bypassing the Firebase Hosting rewrite.

This is intended to diagnose whether the 404 error is caused by the rewrite rule or the function itself.