### PR TITLE
Fix: Simplify Firebase Hosting rewrite rule for leaderboard

### DIFF
--- a/assets/js/leaderboard.js
+++ b/assets/js/leaderboard.js
@@ -47,7 +47,7 @@ async function loadLeaderboard() {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
 
-    const response = await fetch('https://handlegetleaderboard-r7f4oo4gjq-uc.a.run.app', {
+    const response = await fetch('/leaderboard', {
       method: 'GET',
       signal: controller.signal,
       headers: {

--- a/firebase.json
+++ b/firebase.json
@@ -69,10 +69,7 @@
       },
       {
         "source": "/leaderboard",
-        "function": {
-          "functionId": "handlegetleaderboard",
-          "codebase": "python-api"
-        }
+        "function": "handlegetleaderboard"
       },
       {
         "source": "/auto_award_achievement",


### PR DESCRIPTION
This change simplifies the rewrite rule for the `/leaderboard` endpoint in `firebase.json` as suggested by Firebase Support.

The previous, more complex syntax may have been causing issues in the deployment environment. The new, simpler syntax should be more robust.