### PR TITLE
feat: Integrate Sentry for error reporting

### DIFF
--- a/assets/js/global-error-handler.js
+++ b/assets/js/global-error-handler.js
@@ -1,69 +1,15 @@
-(function() {
-    function displayError(message, source, lineno, colno, error) {
-        // Prevent recursive errors
-        if (document.getElementById('global-error-overlay')) {
-            return;
-        }
-
-        const overlay = document.createElement('div');
-        overlay.id = 'global-error-overlay';
-        overlay.style.position = 'fixed';
-        overlay.style.top = '0';
-        overlay.style.left = '0';
-        overlay.style.width = '100%';
-        overlay.style.height = '100%';
-        overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.8)';
-        overlay.style.color = 'white';
-        overlay.style.zIndex = '999999';
-        overlay.style.padding = '20px';
-        overlay.style.fontFamily = 'monospace';
-        overlay.style.fontSize = '14px';
-        overlay.style.overflow = 'auto';
-
-        const errorBox = document.createElement('div');
-        errorBox.style.backgroundColor = '#330000';
-        errorBox.style.border = '2px solid red';
-        errorBox.style.borderRadius = '8px';
-        errorBox.style.padding = '20px';
-        errorBox.style.maxWidth = '800px';
-        errorBox.style.margin = 'auto';
-
-        let errorMessage = '<h2>A Critical Error Occurred</h2>';
-        errorMessage += '<p><strong>Message:</strong> ' + message + '</p>';
-        if (source) {
-            errorMessage += '<p><strong>Source:</strong> ' + source + ':' + lineno + ':' + colno + '</p>';
-        }
-        if (error && error.stack) {
-            errorMessage += '<p><strong>Stack Trace:</strong></p><pre>' + error.stack + '</pre>';
-        }
-
-        errorBox.innerHTML = errorMessage;
-        overlay.appendChild(errorBox);
-        document.body.appendChild(overlay);
-
-        // Also log to console
-        console.error("Global Error Handler Caught:", {
-            message: message,
-            source: source,
-            lineno: lineno,
-            colno: colno,
-            error: error
-        });
-    }
-
-    window.onerror = function(message, source, lineno, colno, error) {
-        displayError(message, source, lineno, colno, error);
-        return true; // Prevents the default browser error handling
-    };
-
-    window.addEventListener('unhandledrejection', function(event) {
-        let reason = event.reason;
-        if (reason instanceof Error) {
-            displayError(reason.message, reason.fileName || 'Promise', reason.lineNumber, reason.columnNumber, reason);
-        } else {
-            displayError(String(reason), 'Promise', null, null, null);
-        }
-    });
-
-    console.log('Global error handler initialized.');
-})();
+Sentry.init({
+  dsn: "https://e1a66c779d41f9c6057dbf22ee53ab8d@o4510070455992320.ingest.us.sentry.io/4510070931783680",
+  integrations: [
+    new Sentry.BrowserTracing({
+      // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: ["localhost", /^https:/],
+    }),
+    new Sentry.Replay(),
+  ],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+});

--- a/index.html
+++ b/index.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
+    <script
+      src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
+      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      crossorigin="anonymous"
+    ></script>
     <script src="/assets/js/global-error-handler.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This commit integrates Sentry.io for error reporting and session replay.

- Adds the Sentry Browser SDK via CDN to `index.html`.
- Initializes Sentry in `assets/js/global-error-handler.js` with the provided DSN.
- Replaces the previous custom error handling logic with Sentry's robust error capturing.
- Configures performance monitoring and session replay to provide more context for debugging.