### PR TITLE
fix(js): Correct Firebase module import path

### DIFF
--- a/assets/js/firebase-core.js
+++ b/assets/js/firebase-core.js
@@ -1,4 +1,4 @@
-import { getFirebaseConfig } from '/assets/js/firebase-config.js';
+import { getFirebaseConfig } from './firebase-config.js';
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-auth.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";


### PR DESCRIPTION
The `firebase-core.js` module was using a root-relative path (`/assets/js/firebase-config.js`) to import its configuration. This can be brittle and was causing a module resolution failure, which prevented Firebase from initializing correctly.

This failure was the root cause of the dashboard and other pages hanging on the loading screen.

This change corrects the import to use a relative path (`./firebase-config.js`), ensuring that the module is loaded correctly and that Firebase services can be initialized. This resolves the site-wide loading issues.