### PR TITLE
fix: Correct Sentry CDN integrity hash

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/gallery.html
+++ b/gallery.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/jonny.html
+++ b/jonny.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/login.html
+++ b/login.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/profile.html
+++ b/profile.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/qna.html
+++ b/qna.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/signup.html
+++ b/signup.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/sponsorship.html
+++ b/sponsorship.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>

--- a/videos.html
+++ b/videos.html
@@ -3,7 +3,7 @@
 <head>
     <script
       src="https://browser.sentry-cdn.com/7.75.0/bundle.min.js"
-      integrity="sha384-gt8o3c9d1a93l4J1d8I1dZ7iUPk5TjM2Gv/7A/N4gZJDB4XgE9NQb2aO/p5s3S4w"
+      integrity="sha384-FM8nH2ja7qI4b4v5soGi0r1bx88cFFUgI64sc4yMmoAa6iwO95o7Sqxn6xgfuyKs"
       crossorigin="anonymous"
     ></script>
     <script>


### PR DESCRIPTION
This commit fixes a critical bug where the Sentry CDN script was being blocked by the browser due to an incorrect SRI integrity hash.

- Updates the `integrity` attribute for the Sentry CDN script tag in all HTML files to the correct SHA-384 hash.
- This resolves the `Sentry is not defined` error and ensures that Sentry is loaded and initialized correctly on all pages.