### PR TITLE
feat: lazy-load Sentry in production only; add conditional DSN check

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -136,3 +136,12 @@ async function initFirebase() {
 
 // Initialize Firebase functionality
 initFirebase();
+
+// Lazy-load Sentry only in production and only if DSN is present
+if (process.env.NODE_ENV === 'production') {
+  setTimeout(() => {
+    import(/* webpackChunkName: "sentry" */ './sentry-init.js')
+      .then(({ initSentry }) => initSentry && initSentry())
+      .catch(() => {});
+  }, 0);
+}

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -58,6 +58,16 @@ import "./app.js";
     }
   }
 
+  // Lazy-load Sentry once per page if configured and in production
+  if (process.env.NODE_ENV === 'production' && !window.__sentryLoaded) {
+    window.__sentryLoaded = true;
+    setTimeout(() => {
+      import(/* webpackChunkName: "sentry" */ './sentry-init.js')
+        .then(({ initSentry }) => initSentry && initSentry())
+        .catch(() => {});
+    }, 0);
+  }
+
   // Enhanced initialization with error handling and retry mechanism
   function initNavigation() {
     if (navigationInitialized) {

--- a/assets/js/sentry-init.js
+++ b/assets/js/sentry-init.js
@@ -1,0 +1,32 @@
+// Lazy Sentry initialization. This file is loaded via dynamic import only in production
+// and only if a DSN is present on window.SENTRY_DSN or in a <meta name="sentry-dsn" /> tag.
+
+export async function initSentry() {
+  try {
+    const dsn =
+      (typeof window !== "undefined" && window.SENTRY_DSN) ||
+      (document && document.querySelector('meta[name="sentry-dsn"]')?.content) ||
+      null;
+
+    if (!dsn) {
+      return; // No DSN configured; skip
+    }
+
+    const [{ init, BrowserTracing, Replay }, { captureException }] = await Promise.all([
+      import(/* webpackChunkName: "sentry" */ "@sentry/browser"),
+      import(/* webpackChunkName: "sentry" */ "@sentry/browser")
+    ]);
+
+    // Note: Keep integrations list minimal to reduce bytes; tracing/replay are optional.
+    init({
+      dsn,
+      integrations: [new BrowserTracing()],
+      tracesSampleRate: 0.1,
+      replaysSessionSampleRate: 0.0,
+      replaysOnErrorSampleRate: 0.2,
+    });
+  } catch (e) {
+    // Swallow errors to avoid impacting UX
+    // console.warn('Sentry init skipped:', e);
+  }
+}


### PR DESCRIPTION
Performance: dynamically import Sentry chunk to avoid loading on pages without DSN. Build: chunk named 'sentry' via webpackChunkName for caching.