### PR TITLE
fix(android): change admin console hamburger menu to floating button

### DIFF
--- a/admin-console.html
+++ b/admin-console.html
@@ -733,19 +733,13 @@
       </aside>
       
       <!-- Main Content -->
-      <main class="flex-1 overflow-hidden">
+      <main class="flex-1 overflow-hidden relative">
+        <!-- Fixed Mobile Menu Button (Top Left) -->
+        <button id="mobile-menu-button-main" class="lg:hidden fixed top-4 left-4 z-[9998] bg-slate-800/90 border border-yellow-400/30 text-yellow-400 w-10 h-10 rounded-lg flex items-center justify-center shadow-[0_4px_12px_rgba(0,0,0,0.5)] backdrop-blur-sm focus:outline-none transition-transform hover:scale-105 active:scale-95">
+          <i class="fas fa-bars text-xl"></i>
+        </button>
         <!-- Mobile Navigation -->
         <div class="md:hidden bg-slate-900/95 border-b border-white/10 px-3 pt-2 pb-1">
-          <!-- Mobile Hamburger Menu Button -->
-          <div class="flex items-center justify-between mb-2">
-            <button id="mobile-menu-button-main" class="text-white focus:outline-none flex items-center justify-center bg-slate-800/80 border border-slate-700 rounded-lg w-9 h-9 shadow">
-              <svg class="w-5 h-5 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
-              </svg>
-            </button>
-            <div class="text-sm font-bold text-white uppercase tracking-wider flex items-center"><i class="fas fa-crown text-yellow-400 mr-2 text-xs"></i> Admin Console</div>
-            <div class="w-9"></div> <!-- spacer for centering -->
-          </div>
           <!-- Primary actions -->
           <div class="flex space-x-2 mb-2">
             <a href="#overview" class="mobile-tab-btn flex-1 py-1.5 rounded-full text-[11px] font-bold text-center bg-blue-600 text-white">Overview</a>

--- a/android/app/src/main/assets/www/admin-console.html
+++ b/android/app/src/main/assets/www/admin-console.html
@@ -733,19 +733,13 @@
       </aside>
       
       <!-- Main Content -->
-      <main class="flex-1 overflow-hidden">
+      <main class="flex-1 overflow-hidden relative">
+        <!-- Fixed Mobile Menu Button (Top Left) -->
+        <button id="mobile-menu-button-main" class="lg:hidden fixed top-4 left-4 z-[9998] bg-slate-800/90 border border-yellow-400/30 text-yellow-400 w-10 h-10 rounded-lg flex items-center justify-center shadow-[0_4px_12px_rgba(0,0,0,0.5)] backdrop-blur-sm focus:outline-none transition-transform hover:scale-105 active:scale-95">
+          <i class="fas fa-bars text-xl"></i>
+        </button>
         <!-- Mobile Navigation -->
         <div class="md:hidden bg-slate-900/95 border-b border-white/10 px-3 pt-2 pb-1">
-          <!-- Mobile Hamburger Menu Button -->
-          <div class="flex items-center justify-between mb-2">
-            <button id="mobile-menu-button-main" class="text-white focus:outline-none flex items-center justify-center bg-slate-800/80 border border-slate-700 rounded-lg w-9 h-9 shadow">
-              <svg class="w-5 h-5 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path>
-              </svg>
-            </button>
-            <div class="text-sm font-bold text-white uppercase tracking-wider flex items-center"><i class="fas fa-crown text-yellow-400 mr-2 text-xs"></i> Admin Console</div>
-            <div class="w-9"></div> <!-- spacer for centering -->
-          </div>
           <!-- Primary actions -->
           <div class="flex space-x-2 mb-2">
             <a href="#overview" class="mobile-tab-btn flex-1 py-1.5 rounded-full text-[11px] font-bold text-center bg-blue-600 text-white">Overview</a>


### PR DESCRIPTION
* Changed the in-document hamburger menu to a floating sticky button (`fixed top-4 left-4`) so that it remains accessible regardless of scroll position on the Android app, matching the user's expected native drawer experience
* Retained the sliding animation and logic
* Re-synced `android-console.html` root file to Android assets
* Re-generated the Android debug bundle.