### PR TITLE
Remove hardcoded bootstrap admin email

### DIFF
--- a/.github/SECRET_SETUP.md
+++ b/.github/SECRET_SETUP.md
@@ -47,6 +47,12 @@ Paste into the secret (single line).
 
 Copy `.env.example` to `.env` for optional local tooling. `.env` is gitignored.
 
+## Firebase Functions runtime configuration
+
+| Name | Where | Purpose |
+|------|-------|---------|
+| `ADMIN_BOOTSTRAP_EMAILS` | Firebase Functions runtime env | Optional, comma-separated list of emails allowed to **self-promote** to `admin` via the `setAdminRole` callable when they have no role yet. Example: `auh­ren1992@gmail.com` |
+
 ## Cursor / cloud AI
 
 `.cursorignore` limits indexing of mobile Firebase config files and keystores so cloud sessions don’t pull those paths into context by default. Your **GitHub secrets** are never in the repo; only **Actions** can read them at build time.

--- a/android/app/src/main/assets/www/functions/index.js
+++ b/android/app/src/main/assets/www/functions/index.js
@@ -983,11 +983,25 @@ exports.setAdminRole = onCall({ secrets: ["SENTRY_DSN"] }, async (request) => {
     throw new HttpsError('invalid-argument', 'Target email is required');
   }
 
-  // Allow initial admin setup for your email specifically
-  const isInitialSetup = targetEmail === 'partspimp75@gmail.com' && !currentUserRole;
+  // Optional bootstrap: allow self-promotion only when explicitly configured.
+  // Set ADMIN_BOOTSTRAP_EMAILS="you@example.com,other@example.com" in the functions runtime env.
+  // This avoids hardcoding a personal email in source control.
+  const bootstrapEmails = (process.env.ADMIN_BOOTSTRAP_EMAILS || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  const callerEmail = String(request.auth.token.email || '').trim().toLowerCase();
+  const targetEmailNormalized = String(targetEmail).trim().toLowerCase();
+  const isBootstrapAllowed =
+    !currentUserRole &&
+    role === 'admin' &&
+    callerEmail &&
+    callerEmail === targetEmailNormalized &&
+    bootstrapEmails.includes(targetEmailNormalized);
   const isCurrentAdmin = currentUserRole === 'admin';
 
-  if (!isInitialSetup && !isCurrentAdmin) {
+  if (!isBootstrapAllowed && !isCurrentAdmin) {
     throw new HttpsError('permission-denied', 'Only admins can assign roles');
   }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,9 +2,8 @@ org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
-# Use a project-local JDK for reproducible builds (Windows).
-# (This is safe to keep checked in; adjust if your username differs.)
-org.gradle.java.home=C:\\Users\\Parts\\.jdks\\jdk-17.0.19+10
+# Optional: pin JDK for reproducible builds (set locally if needed; avoid machine-specific paths in Git).
+# org.gradle.java.home=/path/to/jdk-17
 org.gradle.java.installations.auto-download=true
 android.suppressUnsupportedCompileSdk=36
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1038,11 +1038,26 @@ exports.setAdminRole = onCall({ secrets: ["SENTRY_DSN"] }, async (request) => {
     throw new HttpsError('invalid-argument', 'Target email is required');
   }
 
-  // Allow initial admin setup for your email specifically
-  const isInitialSetup = targetEmail === 'partspimp75@gmail.com' && !currentUserRole;
+  // Optional bootstrap: allow self-promotion only when explicitly configured.
+  // Set ADMIN_BOOTSTRAP_EMAILS="you@example.com,other@example.com" in the functions runtime env.
+  // This avoids hardcoding a personal email in source control.
+  const bootstrapEmails = (process.env.ADMIN_BOOTSTRAP_EMAILS || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+
+  const callerEmail = String(request.auth.token.email || '').trim().toLowerCase();
+  const targetEmailNormalized = String(targetEmail).trim().toLowerCase();
+  const isBootstrapAllowed =
+    !currentUserRole &&
+    role === 'admin' &&
+    callerEmail &&
+    callerEmail === targetEmailNormalized &&
+    bootstrapEmails.includes(targetEmailNormalized);
+
   const isCurrentAdmin = currentUserRole === 'admin';
 
-  if (!isInitialSetup && !isCurrentAdmin) {
+  if (!isBootstrapAllowed && !isCurrentAdmin) {
     throw new HttpsError('permission-denied', 'Only admins can assign roles');
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Removes a hardcoded email address that allowed “initial admin setup” in `setAdminRole`.
- Replaces it with an **explicit, config-driven** bootstrap: `ADMIN_BOOTSTRAP_EMAILS`.

### New behavior
- Normal path unchanged: only callers with `role=admin` can assign roles.
- Optional bootstrap: if the caller has **no role yet**, they may set **their own** email to `admin` **only** when their email is included in `ADMIN_BOOTSTRAP_EMAILS`.

### Setup
- See `.github/SECRET_SETUP.md` → **Firebase Functions runtime configuration**.

### Also included
- `android/gradle.properties`: removed a Windows-only `org.gradle.java.home` entry so Gradle uses the environment JDK (fixes Linux/CI and avoids broken paths on other machines). Pin locally if you need a fixed JDK.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

