### PR TITLE
Make Android .aab downloadable via Actions (clearer artifacts + docs)

### DIFF
--- a/.github/SECRET_SETUP.md
+++ b/.github/SECRET_SETUP.md
@@ -12,6 +12,18 @@ Keep this repo **private**. Names below are **references only** (never paste sec
 | `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | **Not listed** — add if you use the Play upload step | Play Console service account JSON (full text). Step skips upload if unset. |
 | `GOOGLE_SERVICES_JSON` | **Optional** — add when ready | Full JSON → overwrites `android/app/google-services.json` before Gradle. If unset, CI uses the file from Git. |
 
+### Download the signed Android bundle (.aab)
+
+Every successful **Android Build** run uploads a downloadable artifact:
+
+1. Open [Actions → Android Build](https://github.com/auhren1992/Redsracing/actions/workflows/android-build.yml).
+2. Click the latest successful run (or **Run workflow** to build on demand).
+3. Scroll to **Artifacts** at the bottom.
+4. Download the artifact named like `reds-racing-aab-v{versionName}-b{versionCode}` (a zip file).
+5. Unzip and upload `app-release.aab` to [Google Play Console](https://play.google.com/console).
+
+The run summary also repeats these steps. Artifacts are kept for **90 days** (see workflow).
+
 ## iOS (`ios-build.yml`)
 
 | Secret | In your repo? | Purpose |

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -16,6 +16,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Read app version
+        id: app_version
+        run: |
+          FILE=android/app/build.gradle.kts
+          VERSION_NAME=$(grep -E 'versionName[[:space:]]*=' "$FILE" | head -1 | sed -E 's/.*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+          VERSION_CODE=$(grep -E 'versionCode[[:space:]]*=' "$FILE" | head -1 | sed -E 's/.*versionCode[[:space:]]*=[[:space:]]*([0-9]+).*/\1/')
+          echo "version_name=$VERSION_NAME" >> "$GITHUB_OUTPUT"
+          echo "version_code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+          echo "App version: $VERSION_NAME (versionCode $VERSION_CODE)"
+
       # Optional: set repo secret GOOGLE_SERVICES_JSON to full JSON so CI/cloud never relies on a stale committed copy.
       - name: Inject google-services.json from secret (optional)
         env:
@@ -80,9 +90,32 @@ jobs:
       - name: Upload Bundle Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: android-bundle
+          name: reds-racing-aab-v${{ steps.app_version.outputs.version_name }}-b${{ steps.app_version.outputs.version_code }}
           path: android/app/build/outputs/bundle/release/*.aab
-          retention-days: 30
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Download instructions (job summary)
+        run: |
+          {
+            echo "## Android App Bundle ready to download"
+            echo ""
+            echo "The signed **Play Store** bundle is published as a workflow artifact (a zip file)."
+            echo ""
+            echo "| | |"
+            echo "|--|--|"
+            echo "| **Artifact name** | \`reds-racing-aab-v${{ steps.app_version.outputs.version_name }}-b${{ steps.app_version.outputs.version_code }}\` |"
+            echo "| **File inside zip** | \`app-release.aab\` |"
+            echo ""
+            echo "### How to download"
+            echo "1. Open this workflow run in the **Actions** tab."
+            echo "2. Scroll to **Artifacts** at the bottom of the page."
+            echo "3. Download the artifact zip, extract it, and use \`app-release.aab\` in [Google Play Console](https://play.google.com/console)."
+            echo ""
+            echo "To trigger a fresh build manually: **Actions → Android Build → Run workflow**."
+            echo ""
+            echo "Workflow file: [\`android-build.yml\`](https://github.com/${{ github.repository }}/actions/workflows/android-build.yml)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Clean up keystore
         if: always()

--- a/README.md
+++ b/README.md
@@ -58,3 +58,13 @@ The project uses Firebase for authentication and Firestore for data storage. See
 ### Note on Tailwind CSS
 
 This project previously used Tailwind CSS via CDN, which showed warnings in production. We've migrated to a local build process using the Tailwind CLI for better production performance and to eliminate the development warnings.
+
+## Android app bundle (download signed .aab)
+
+CI builds a signed **Android App Bundle** on every **Android Build** workflow run.
+
+1. Go to [Android Build workflow runs](https://github.com/auhren1992/Redsracing/actions/workflows/android-build.yml).
+2. Open a successful run (or use **Run workflow** to build manually).
+3. Under **Artifacts**, download `reds-racing-aab-v{version}-b{code}` (zip). Inside is `app-release.aab` for Play Console.
+
+More detail: `.github/SECRET_SETUP.md` → **Download the signed Android bundle (.aab)**.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
The Android workflow already uploaded the signed `.aab` as a GitHub Actions artifact; this change makes that **obvious and easy to use**.

### Changes
- **Versioned artifact name:** `reds-racing-aab-v{versionName}-b{versionCode}` instead of a generic `android-bundle`.
- **Longer retention:** 90 days (was 30).
- **Fail fast:** `if-no-files-found: error` if the bundle is missing.
- **Job summary:** step-by-step download instructions on each successful run.
- **Docs:** `README.md` and `.github/SECRET_SETUP.md` link to the workflow and explain how to download the zip and use `app-release.aab`.

### How to download after merge
[Actions → Android Build](https://github.com/auhren1992/Redsracing/actions/workflows/android-build.yml) → successful run → **Artifacts** at the bottom.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

