### PR TITLE
Fix invalid org.gradle.java.home breaking Gradle on Windows/CI

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 kotlin.code.style=official
-# Use a project-local JDK for reproducible builds (Windows).
-# (This is safe to keep checked in; adjust if your username differs.)
-org.gradle.java.home=C:\\Users\\Parts\\.jdks\\jdk-17.0.19+10
+# Do not commit a machine-specific JDK path — it breaks other machines and CI when the folder moves.
+# To pin a JDK locally, uncomment and set *your* path (or use Android Studio: Settings → Build Tools → Gradle → Gradle JDK).
+# org.gradle.java.home=C:\\Program Files\\Android\\Android Studio\\jbr
 org.gradle.java.installations.auto-download=true
 android.suppressUnsupportedCompileSdk=36
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
`android/gradle.properties` pinned `org.gradle.java.home` to a path under `C:\Users\Parts\.jdks\...`. When that JDK is missing, moved, or the project is used on another machine, Gradle fails with: *Java home supplied is invalid*.

### Change
Remove the checked-in absolute path. Gradle then uses the JDK from the environment / Android Studio (**Gradle JDK** setting). A commented example line documents how to pin a JDK locally without committing machine-specific paths.

### After merge / local workaround
- **Android Studio:** Settings → Build, Execution, Deployment → Build Tools → Gradle → **Gradle JDK** → pick **jbr-17** (or Temurin 17).
- **CLI:** install JDK 17 and ensure `JAVA_HOME` points at it.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9715d6b4-37b8-4c98-af35-5a2a052a523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

