### PR TITLE
fix: override uuid version to patch CVE-2026-41907

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
     "@sentry/tracing": "^7.120.4",
     "firebase": "^12.3.0",
     "firebase-admin": "^13.5.0"
+  },
+  "overrides": {
+    "@google-cloud/storage": {
+      "uuid": "^11.1.1"
+    }
   }
 }


### PR DESCRIPTION
Force @google-cloud/storage to use uuid@^11.1.1 instead of vulnerable 8.3.2