### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ build
 __pycache__/
 *.py[cod]
 *$py.class
+functions_python/venv/
+functions_python/.venv/
 
 # Certificates and private keys
 certificates/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a monorepo for **RedsRacing #8** (Firebase project `redsracing-a7f8b`). The core
+product is a static, multi-page PWA website (root `*.html` + `assets/js/*.js` + `styles/*.css`)
+served by Firebase Hosting, plus two Cloud Functions backends: Node 20 (`functions/`) and
+Python 3.12 (`functions_python/`). Mobile apps (`android/`, `ios/`), the Go stub
+(`services/speedhive-go-service/`) and the PHP `cms/` are auxiliary/optional. Ignore
+`android/app/src/main/assets/**` — it is a bundled duplicate of the whole repo.
+
+The startup update script already installs deps: root `npm install`, `functions/` `npm install`,
+and a Python venv at `functions_python/venv` with `functions_python/requirements.txt`.
+The `python3.12-venv` system package is provided by the VM snapshot (not the update script).
+
+### Running the website (the core product)
+- `npx firebase emulators:start --only hosting` serves the site at `http://127.0.0.1:5000`.
+  `firebase-tools` is a root devDependency, so no global install is needed.
+- Expected/harmless on startup: `You are not currently authenticated`, a `MetadataLookupWarning`
+  (GCE metadata probe), and `Could not fetch web app configuration`. Hosting-only serving does
+  not need `firebase login` or Java, and the client uses hardcoded config in
+  `assets/js/firebase-config.js`. Live Firestore/Auth-backed data won't populate without cloud
+  credentials, but pages render and client JS runs.
+
+### Build caveat (important, non-obvious)
+- `npm run build` (webpack) and `npm run build-css` / `build-css-prod` (Tailwind) CANNOT complete
+  in a fresh clone: `src/` and `dist/` are gitignored, so the Tailwind source `src/input.css` and
+  the webpack entry `assets/js/follower-dashboard.js` are absent. This is expected repo state.
+- You do NOT need to build to run the site: HTML loads JS directly from `assets/js/*.js` and CSS
+  from the committed `styles/tailwind.css` (the webpack `dist/` output is not referenced by pages,
+  except `live.html`). Do not try to "fix" the build by adding these missing source files.
+
+### Cloud Functions
+- Node: `cd functions && npm run serve` (`firebase emulators:start --only functions`). The full
+  functions emulator needs Java (OpenJDK is present on the VM).
+- Python: functions live in `functions_python/` (codebase `python-api`) and use the venv above.
+
+### Tests
+- Canonical suite (mocked, no network):
+  `functions_python/venv/bin/python -m unittest tests.test_profile_endpoints -v` (13 tests, all pass).
+- `test_new_features.py` is a standalone self-check that passes.
+- `test_404_fix.py` FAILS on a pre-existing stale reference (`main.get_mailgun_client` was removed);
+  this is not an environment problem. `test_sentry.py` actually emits events to Sentry — avoid unless intended.
+
+### Lint
+- `npm run lint:firebase-imports` runs `scripts/validate_firebase_imports.js`. It prints a
+  "Bare Firebase imports detected" warning for `assets/js/main.js` but exits 0 (non-blocking).
+- ESLint/Stylelint configs exist (`.eslintrc.json`, `.stylelintrc.json`) but no lint script/binary
+  is wired up in `package.json`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the RedsRacing #8 monorepo so cloud agents can install deps, lint, test, and run the app.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting how to run the static site via the Firebase Hosting emulator, the pre-existing webpack/Tailwind build caveat (source dirs are gitignored, site serves committed static assets), and how to run the functions, tests, and lint.
- Ignores the local Python venv (`functions_python/venv/`).
- Configures a minimal, idempotent startup update script (root `npm install`, `functions/` `npm install`, and a Python venv from `functions_python/requirements.txt`).

No application code was modified.

## What was verified

| Concern | Command | Result |
|---|---|---|
| Frontend deps | `npm install` | 1100 packages installed |
| Node functions deps | `npm install` (in `functions/`) | 626 packages installed |
| Python functions deps | venv + `pip install -r functions_python/requirements.txt` | installed |
| Lint | `npm run lint:firebase-imports` | runs, exits 0 (non-blocking warning) |
| Tests | `functions_python/venv/bin/python -m unittest tests.test_profile_endpoints -v` | 13 passed |
| Run app | `npx firebase emulators:start --only hosting` | serves at `http://127.0.0.1:5000`, HTTP 200 |

## Hello-world demo

Browsed the running site end-to-end: homepage with live countdown + carousel, Schedule page, and Gallery page all render with correct styling and navigation.

[redsracing_site_walkthrough.mp4](https://cursor.com/agents/bc-0b19851d-2e68-4b03-b786-9947644eb306/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fredsracing_site_walkthrough.mp4)

## Notes
- `npm run build` (webpack) and `npm run build-css` (Tailwind) cannot complete in a fresh clone because `src/` and `dist/` are gitignored and their sources are absent — this is expected repo state, and the site is served from committed static assets, so building is not required to run it.
- `test_404_fix.py` fails on a pre-existing stale reference (`main.get_mailgun_client` was removed); unrelated to environment setup.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b19851d-2e68-4b03-b786-9947644eb306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b19851d-2e68-4b03-b786-9947644eb306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

