### PR TITLE
Fix setAdminRole bootstrap email to auhren1992@gmail.com

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -731,7 +731,7 @@ exports.setAdminRole = onCall({ secrets: ["SENTRY_DSN"] }, async (request) => {
   }
 
   // Allow initial admin setup for your email specifically
-  const isInitialSetup = targetEmail === 'partspimp75@gmail.com' && !currentUserRole;
+  const isInitialSetup = targetEmail === 'auhren1992@gmail.com' && !currentUserRole;
   const isCurrentAdmin = currentUserRole === 'admin';
 
   if (!isInitialSetup && !isCurrentAdmin) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the hardcoded initial-setup allowlist email in `setAdminRole` from `partspimp75@gmail.com` to `auhren1992@gmail.com`, matching the rest of the admin tooling and docs.

## Change

```js
// functions/index.js
const isInitialSetup = targetEmail === 'auhren1992@gmail.com' && !currentUserRole;
```

No other `partspimp75@gmail.com` references remain in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b19851d-2e68-4b03-b786-9947644eb306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b19851d-2e68-4b03-b786-9947644eb306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

