### PR TITLE
Rework admin console: remove broken mobile panel, add ops tools

### DIFF
--- a/admin-console.html
+++ b/admin-console.html
@@ -1232,7 +1232,7 @@
                     Command <span class="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 via-amber-300 to-rose-400">Center</span>
                   </h1>
                   <p class="text-slate-400 text-sm md:text-base leading-relaxed max-w-xl">
-                    Approvals, race content, analytics, and ops—one cockpit built for race-night speed.
+                    Approvals, race content, site banner, analytics, and ops—one cockpit built for race-night speed.
                   </p>
                   <div class="mt-4 flex flex-wrap items-center gap-2">
                     <span class="admin-hero-chip"><i class="fas fa-circle text-[0.45rem] opacity-80" aria-hidden="true"></i> Live console</span>
@@ -1316,7 +1316,47 @@
               </div>
             </div>
             
-            <!-- Next Race & Notes Row -->
+            <!-- Quick Actions -->
+            <div class="admin-card rounded-xl p-6">
+              <div class="flex items-center justify-between mb-4">
+                <h2 class="text-xl font-bold text-white">
+                  <i class="fas fa-bolt text-amber-400 mr-2"></i>
+                  Quick Actions
+                </h2>
+                <span class="text-xs text-slate-500">Jump to the jobs you do most</span>
+              </div>
+              <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3" id="overview-quick-actions">
+                <a href="#inbox" class="bg-slate-800/60 border border-slate-700/50 hover:border-cyan-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-inbox text-cyan-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Inbox</div>
+                </a>
+                <a href="#media" class="bg-slate-800/60 border border-slate-700/50 hover:border-purple-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-images text-purple-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Gallery</div>
+                </a>
+                <a href="#race" class="bg-slate-800/60 border border-slate-700/50 hover:border-yellow-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-flag-checkered text-yellow-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Results</div>
+                </a>
+                <a href="push-notifications.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-orange-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-bell text-orange-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Notify</div>
+                </a>
+                <a href="#schedule-mgmt" class="bg-slate-800/60 border border-slate-700/50 hover:border-green-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-calendar-alt text-green-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Schedule</div>
+                </a>
+                <a href="live-race-admin.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-red-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-broadcast-tower text-red-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Go Live</div>
+                </a>
+              </div>
+            </div>
+
+            <!-- Overview tools mount (site banner, staff notes, attention digest) -->
+            <div id="overview-tools" class="grid grid-cols-1 lg:grid-cols-2 gap-6"></div>
+
+                        <!-- Next Race & Notes Row -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <!-- Next Race Countdown -->
               <div class="admin-card rounded-xl p-6">
@@ -2440,187 +2480,6 @@
                 <div id="backup-operation-result" class="mt-3 text-sm text-slate-300"></div>
               </div>
 
-              <!-- Mobile App Management -->
-              <div class="admin-card rounded-xl p-6">
-                <h3 class="text-xl font-bold text-white mb-4">
-                  <i class="fas fa-mobile-alt text-cyan-400 mr-2"></i>
-                  Mobile App Management
-                </h3>
-                <p class="text-slate-400 text-sm mb-4">Monitor your Android and iOS apps</p>
-                
-                <!-- App Stats -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                  <!-- Android -->
-                  <div class="bg-gradient-to-br from-green-900/30 to-slate-800/30 border border-green-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-android text-green-400 mr-2 text-xl"></i>Android App
-                      </h4>
-                      <span id="android-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="android-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-green-400 font-medium" id="android-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="android-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="android-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- iOS -->
-                  <div class="bg-gradient-to-br from-blue-900/30 to-slate-800/30 border border-blue-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-apple text-blue-400 mr-2 text-xl"></i>iOS App
-                      </h4>
-                      <span id="ios-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="ios-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-blue-400 font-medium" id="ios-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="ios-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="ios-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
-                <!-- App Version Management -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">App Version Management</h4>
-                  
-                  <!-- Version Distribution Stats -->
-                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">Android Version Distribution</h5>
-                      <div id="android-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">iOS Version Distribution</h5>
-                      <div id="ios-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- Android Version Config -->
-                  <div class="bg-slate-900/50 border border-green-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-android text-green-400 mr-2"></i>Android Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="android-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="android-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="android-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <!-- iOS Version Config -->
-                  <div class="bg-slate-900/50 border border-blue-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-apple text-blue-400 mr-2"></i>iOS Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="ios-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="ios-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="ios-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <div class="flex justify-end space-x-2">
-                    <button id="load-version-config-btn" class="modern-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-sync mr-2"></i>Load Current
-                    </button>
-                    <button id="save-version-config-btn" class="success-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-save mr-2"></i>Save Config
-                    </button>
-                  </div>
-                </div>
-                
-                <!-- Push Notifications -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">Send Push Notification</h4>
-                  <div class="space-y-3">
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Platform</label>
-                      <select id="push-platform" class="modern-input w-full p-2 text-white">
-                        <option value="both">Both (Android + iOS)</option>
-                        <option value="android">Android Only</option>
-                        <option value="ios">iOS Only</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Title</label>
-                      <input type="text" id="push-title" class="modern-input w-full p-2 text-white" placeholder="Race Alert!" />
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Message</label>
-                      <textarea id="push-message" rows="2" class="modern-input w-full p-2 text-white resize-none" placeholder="Next race starts in 1 hour!"></textarea>
-                    </div>
-                  </div>
-                  <div class="mt-4 flex justify-end">
-                    <button id="send-push-notification-btn" class="success-btn text-white px-4 py-2 rounded text-sm">
-                      <i class="fas fa-bell mr-2"></i>Send Notification
-                    </button>
-                  </div>
-                </div>
-                
-                <div class="flex flex-wrap gap-2">
-                  <button id="refresh-app-stats-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-sync mr-2"></i>Refresh Stats
-                  </button>
-                  <button id="view-crash-reports-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-bug mr-2"></i>View Crash Reports
-                  </button>
-                  <button id="app-analytics-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-chart-bar mr-2"></i>App Analytics
-                  </button>
-                </div>
-                <div id="app-operation-result" class="mt-3 text-sm text-slate-300"></div>
-              </div>
-
               <!-- Revenue & Monetization -->
               <div class="admin-card rounded-xl p-6">
                 <h3 class="text-xl font-bold text-white mb-4">
@@ -3217,7 +3076,7 @@
                     <i class="fas fa-heartbeat text-red-400 mr-3"></i>
                     Site Health Dashboard
                   </h2>
-                  <p class="text-slate-400 text-sm mt-1">Monitor app versions, system status, and error rates</p>
+                  <p class="text-slate-400 text-sm mt-1">Monitor site status, system health, and error rates</p>
                 </div>
                 <div class="flex items-center space-x-3">
                   <span class="text-slate-500 text-xs" id="health-last-check"></span>
@@ -3227,25 +3086,9 @@
                 </div>
               </div>
 
-              <!-- App Versions -->
-              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-mobile-alt text-blue-400 mr-2"></i>App Versions</h3>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-android text-green-400 text-xl"></i>
-                    <span class="text-white font-semibold">Android</span>
-                  </div>
-                  <div class="text-2xl font-bold text-green-400" id="health-android-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-android-code">Build --</div>
-                </div>
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-apple text-slate-300 text-xl"></i>
-                    <span class="text-white font-semibold">iOS</span>
-                  </div>
-                  <div class="text-2xl font-bold text-slate-300" id="health-ios-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-ios-code">Build --</div>
-                </div>
+              <!-- Site Version -->
+              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-globe text-blue-400 mr-2"></i>Site Version</h3>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                 <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
                   <div class="flex items-center space-x-3 mb-2">
                     <i class="fas fa-globe text-blue-400 text-xl"></i>
@@ -3253,6 +3096,14 @@
                   </div>
                   <div class="text-2xl font-bold text-blue-400" id="health-web-ver">--</div>
                   <div class="text-xs text-slate-500" id="health-web-url">redsracing.org</div>
+                </div>
+                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
+                  <div class="flex items-center space-x-3 mb-2">
+                    <i class="fas fa-bullhorn text-amber-400 text-xl"></i>
+                    <span class="text-white font-semibold">Public Banner</span>
+                  </div>
+                  <div class="text-lg font-semibold text-amber-300" id="health-banner-status">--</div>
+                  <div class="text-xs text-slate-500" id="health-banner-preview">Managed from Overview tools</div>
                 </div>
               </div>
 
@@ -5759,26 +5610,23 @@
             // Reset stat values to show loading
             ['health-errors-24h','health-errors-7d','health-subscribers'].forEach(id => el(id, '...'));
             el('health-top-error-page', '...');
-            // ---- App versions from app_config (replaces hardcoded values) ----
-            try {
-              const androidCfg = await getDoc(doc(db, 'app_config', 'android_version'));
-              if (androidCfg.exists()) {
-                const d = androidCfg.data();
-                el('health-android-ver', d.version_name || d.latest_version || '?');
-                el('health-android-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-android-ver', 'No config'); el('health-android-code', '--'); }
-              const iosCfg = await getDoc(doc(db, 'app_config', 'ios_version'));
-              if (iosCfg.exists()) {
-                const d = iosCfg.data();
-                el('health-ios-ver', d.version_name || d.latest_version || '?');
-                el('health-ios-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-ios-ver', 'No config'); el('health-ios-code', '--'); }
-            } catch(e) {
-              console.warn('Failed to read app_config versions:', e);
-              el('health-android-ver', '?'); el('health-android-code', '?');
-              el('health-ios-ver', '?'); el('health-ios-code', '?');
-            }
+            // ---- Site version + public banner status ----
             el('health-web-ver', document.querySelector('meta[name="app-version"]')?.content || 'live');
+            try {
+              const bannerCfg = await getDoc(doc(db, 'config', 'site_banner'));
+              if (bannerCfg.exists()) {
+                const d = bannerCfg.data() || {};
+                const on = !!d.enabled;
+                el('health-banner-status', on ? (d.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off');
+                el('health-banner-preview', (d.message || '').toString().slice(0, 80) || 'No message set');
+              } else {
+                el('health-banner-status', 'Off');
+                el('health-banner-preview', 'No banner configured');
+              }
+            } catch (e) {
+              el('health-banner-status', '?');
+              el('health-banner-preview', 'Could not load');
+            }
             // Firebase status
             const setStatus = (prefix, ok, msg) => {
               const dot = document.getElementById(prefix + '-dot');
@@ -7127,18 +6975,6 @@
         
         // ===== NEW ADMIN TOOLS FUNCTIONS =====
 
-        function __isAndroidAppUserAgent(ua) {
-          const s = String(ua || '').toLowerCase();
-          if (!s) return false;
-          return s.includes('android') && (s.includes('; wv') || s.includes('redsracingapp'));
-        }
-
-        function __isIosAppUserAgent(ua) {
-          const s = String(ua || '');
-          if (!s) return false;
-          return /iphone|ipad|ipod/i.test(s) && (s.includes('Mobile/') || s.includes('RedsRacingApp'));
-        }
-
         async function loadEmailMarketingStats() {
           const { getFirestore, collection, getDocs, query, orderBy, limit, getCountFromServer } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
           const app = await ensureDefaultApp();
@@ -7198,16 +7034,6 @@
             document.getElementById('backup-size').textContent = '0 KB';
             document.getElementById('backup-count').textContent = '0';
             
-            // Mobile App stats (versions come from app_config via loadVersionConfig)
-            document.getElementById('android-version').textContent = '--';
-            document.getElementById('ios-version').textContent = '--';
-            document.getElementById('android-users').textContent = '--';
-            document.getElementById('ios-users').textContent = '--';
-            document.getElementById('android-crashes').textContent = '--';
-            document.getElementById('ios-crashes').textContent = '--';
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-            
             // Revenue stats
             document.getElementById('revenue-today').textContent = '$--';
             document.getElementById('revenue-month').textContent = '$--';
@@ -7224,12 +7050,6 @@
             
             // Load initial activity stats
             try { await refreshUserActivity(); } catch(e) { console.warn('Activity refresh failed:', e); }
-            // Load initial app stats
-            try { await refreshAppStats(); } catch(e) { console.warn('App stats refresh failed:', e); }
-            // Load configured app versions into cards + form
-            try { await loadVersionConfig(); } catch(e) { console.warn('Version config load failed:', e); }
-            // Load version distribution
-            try { await loadVersionDistribution(); } catch(e) { console.warn('Version distribution load failed:', e); }
             // Load initial revenue stats
             try { await refreshRevenueStats(); } catch(e) { console.warn('Revenue stats refresh failed:', e); }
           } catch(e) {
@@ -7348,25 +7168,6 @@
           
           const exportAllDataBtn = document.getElementById('export-all-data-btn');
           if (exportAllDataBtn) exportAllDataBtn.addEventListener('click', exportAllData);
-          
-          // Mobile App Management
-          const loadVersionConfigBtn = document.getElementById('load-version-config-btn');
-          if (loadVersionConfigBtn) loadVersionConfigBtn.addEventListener('click', loadVersionConfig);
-          
-          const saveVersionConfigBtn = document.getElementById('save-version-config-btn');
-          if (saveVersionConfigBtn) saveVersionConfigBtn.addEventListener('click', saveVersionConfig);
-          
-          const refreshAppStatsBtn = document.getElementById('refresh-app-stats-btn');
-          if (refreshAppStatsBtn) refreshAppStatsBtn.addEventListener('click', refreshAppStats);
-          
-          const sendPushNotificationBtn = document.getElementById('send-push-notification-btn');
-          if (sendPushNotificationBtn) sendPushNotificationBtn.addEventListener('click', sendPushNotification);
-          
-          const viewCrashReportsBtn = document.getElementById('view-crash-reports-btn');
-          if (viewCrashReportsBtn) viewCrashReportsBtn.addEventListener('click', viewCrashReports);
-          
-          const appAnalyticsBtn = document.getElementById('app-analytics-btn');
-          if (appAnalyticsBtn) appAnalyticsBtn.addEventListener('click', showAppAnalytics);
           
           // Revenue & Monetization
           const refreshRevenueBtn = document.getElementById('refresh-revenue-btn');
@@ -8816,710 +8617,6 @@
           const simple = s.match(/\d+\.\d+/);
           if (simple && simple[0]) return simple[0];
           return '';
-        }
-        
-        async function refreshAppStats() {
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const msDay = 86400000;
-            const cutoff7d = Timestamp.fromDate(new Date(Date.now() - 7 * msDay));
-
-            const toMillis = (ts) => {
-              try {
-                if (!ts) return null;
-                if (ts.toMillis) return ts.toMillis();
-                const d = ts.toDate ? ts.toDate() : new Date(ts);
-                const n = d.getTime();
-                return Number.isFinite(n) ? n : null;
-              } catch (_) {
-                return null;
-              }
-            };
-
-            // --- Real install / activity signals from app_usage (FCM token doc IDs) ---
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            let androidTotal = 0;
-            let iosTotal = 0;
-            let androidSeen7d = 0;
-            let iosSeen7d = 0;
-            let androidLatestSeen = null;
-            let iosLatestSeen = null;
-            let androidLatestName = '';
-            let iosLatestName = '';
-
-            usageSnap.forEach((docSnap) => {
-              const d = docSnap.data() || {};
-              const platform = String(d.platform || '').toLowerCase();
-              const lastMs = toMillis(d.last_seen) ?? toMillis(d.lastSeen);
-              const seenRecently = lastMs !== null && lastMs >= (Date.now() - 7 * msDay);
-
-              const parsed =
-                extractVersionCode(d.app_version_code) ??
-                extractVersionCode(d.versionCode) ??
-                extractVersionCode(d.build) ??
-                extractVersionCode(d.app_version) ??
-                extractVersionCode(d.version) ??
-                extractVersionCode(d.appVersion);
-              const parsedName =
-                extractVersionName(d.app_version_name) ||
-                extractVersionName(d.versionName) ||
-                extractVersionName(d.app_version) ||
-                extractVersionName(d.version) ||
-                extractVersionName(d.appVersion);
-
-              if (platform === 'android') {
-                androidTotal += 1;
-                if (seenRecently) androidSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  androidLatestSeen = androidLatestSeen === null ? parsed : Math.max(androidLatestSeen, parsed);
-                  if (parsedName) androidLatestName = parsedName;
-                } else if (parsedName) {
-                  androidLatestName = parsedName;
-                }
-              } else if (platform === 'ios') {
-                iosTotal += 1;
-                if (seenRecently) iosSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  iosLatestSeen = iosLatestSeen === null ? parsed : Math.max(iosLatestSeen, parsed);
-                  if (parsedName) iosLatestName = parsedName;
-                } else if (parsedName) {
-                  iosLatestName = parsedName;
-                }
-              }
-            });
-
-            const androidUsersEl = document.getElementById('android-users');
-            const iosUsersEl = document.getElementById('ios-users');
-            if (androidUsersEl) androidUsersEl.textContent = androidTotal ? `${androidSeen7d} / ${androidTotal}` : '--';
-            if (iosUsersEl) iosUsersEl.textContent = iosTotal ? `${iosSeen7d} / ${iosTotal}` : '--';
-
-            // --- WebView JS error rate (7d): client_logs errors vs page_views in app WebViews ---
-            const isTrackedError = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            const classifyPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              if (__isAndroidAppUserAgent(ua)) return 'android';
-              if (__isIosAppUserAgent(ua)) return 'ios';
-              if (String(url).includes('appassets.androidplatform.net')) return 'android';
-              return null;
-            };
-
-            let logs = [];
-            try {
-              const logSnap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff7d), orderBy('serverTimestamp', 'desc'), limit(1500)));
-              logs = logSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const logSnap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(1500)));
-                logs = logSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                logs = [];
-              }
-            }
-
-            let pv = [];
-            try {
-              const pvSnap = await getDocs(query(collection(db, 'page_views'), where('timestamp', '>=', cutoff7d), orderBy('timestamp', 'desc'), limit(4000)));
-              pv = pvSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(4000)));
-                pv = pvSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                pv = [];
-              }
-            }
-
-            const cutoffMs = Date.now() - 7 * msDay;
-            const logInWindow = (v) => {
-              const ms = toMillis(v.serverTimestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-            const pvInWindow = (v) => {
-              const ms = toMillis(v.timestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-
-            const logsW = logs.filter(logInWindow);
-            const pvW = pv.filter(pvInWindow);
-
-            const errAndroid = logsW.filter((v) => isTrackedError(v) && __isAndroidAppUserAgent(v.userAgent)).length;
-            const errIos = logsW.filter((v) => isTrackedError(v) && __isIosAppUserAgent(v.userAgent)).length;
-            const pvAndroid = pvW.filter((v) => classifyPv(v) === 'android').length;
-            const pvIos = pvW.filter((v) => classifyPv(v) === 'ios').length;
-
-            const fmtRate = (errs, views) => {
-              if (!views) return 'N/A';
-              return `${((errs / views) * 100).toFixed(2)}%`;
-            };
-
-            const androidCrashEl = document.getElementById('android-crashes');
-            const iosCrashEl = document.getElementById('ios-crashes');
-            if (androidCrashEl) androidCrashEl.textContent = fmtRate(errAndroid, pvAndroid);
-            if (iosCrashEl) iosCrashEl.textContent = fmtRate(errIos, pvIos);
-
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-
-            // Use config minimums if available (for display only)
-            const androidMin = parseInt(document.getElementById('android-min-version')?.value, 10);
-            const iosMin = parseInt(document.getElementById('ios-min-version')?.value, 10);
-
-            if (androidLatestSeen !== null || androidLatestName) {
-              const codePart = Number.isFinite(androidLatestSeen) ? androidLatestSeen : '';
-              const namePart = androidLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(androidMin) && codePart !== '') {
-                label = `${label} · min ${androidMin}`;
-              }
-              document.getElementById('android-version').textContent = label;
-            }
-            if (iosLatestSeen !== null || iosLatestName) {
-              const codePart = Number.isFinite(iosLatestSeen) ? iosLatestSeen : '';
-              const namePart = iosLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(iosMin) && codePart !== '') {
-                label = `${label} · min ${iosMin}`;
-              }
-              document.getElementById('ios-version').textContent = label;
-            }
-
-            // Real status badges based on whether we've seen recent traffic
-            // from the platform (last 7 days of page_views with the matching
-            // user-agent). Replaces the always-on hardcoded "Live" labels.
-            const androidBadge = document.getElementById('android-status-badge');
-            const iosBadge = document.getElementById('ios-status-badge');
-            if (androidBadge) {
-              const seen = parseInt(document.getElementById('android-users')?.textContent || '0', 10) > 0;
-              androidBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              androidBadge.className = `px-2 py-1 ${seen ? 'bg-green-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-            if (iosBadge) {
-              const seen = parseInt(document.getElementById('ios-users')?.textContent || '0', 10) > 0;
-              iosBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              iosBadge.className = `px-2 py-1 ${seen ? 'bg-blue-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App stats refreshed from <span class="text-slate-200">app_usage</span>, <span class="text-slate-200">page_views</span>, and <span class="text-slate-200">client_logs</span></div>';
-            showToast('App stats refreshed');
-          } catch(e) {
-            console.error('Failed to refresh app stats:', e);
-            showToast('Failed to refresh app stats', 'error');
-          }
-        }
-        
-        async function sendPushNotification() {
-          try {
-            console.log('[Push Notification] Checking user role...');
-            const role = await getUserRole();
-            console.log('[Push Notification] User role:', role);
-            
-            if (!role) {
-              console.error('[Push Notification] No role found - user may not be authenticated');
-              showToast('Please log in to send push notifications', 'error');
-              return;
-            }
-            
-            if (!isModeratorRole(role)) {
-              console.warn('[Push Notification] User role insufficient:', role);
-              showToast(`You need to be a team-member or admin to send push notifications (current role: ${role})`, 'error');
-              return;
-            }
-            
-            console.log('[Push Notification] Role check passed:', role);
-            
-            const platform = document.getElementById('push-platform').value;
-            const title = document.getElementById('push-title').value;
-            const message = document.getElementById('push-message').value;
-            
-            if (!title || !message) {
-              showToast('Please fill in title and message', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Sending...';
-            
-            const { getFirestore, collection, addDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            // Store notification in Firestore for Cloud Function to send
-            try {
-              const notificationData = {
-                platform,
-                title,
-                message,
-                timestamp: serverTimestamp(),
-                sentBy: auth.currentUser?.uid || null,
-                status: 'pending'
-              };
-              
-              await addDoc(collection(db, 'push_notifications'), notificationData);
-              
-              // Also log to admin logs
-              await addDoc(collection(db, 'admin_logs'), {
-                action: 'push_notification_sent',
-                platform,
-                title,
-                message: message.substring(0, 100),
-                timestamp: serverTimestamp(),
-                uid: auth.currentUser?.uid || null,
-                role: role || 'unknown'
-              });
-            } catch(error) {
-              console.error('Failed to queue push notification:', error);
-              throw error;
-            }
-            
-            // Clear form
-            document.getElementById('push-title').value = '';
-            document.getElementById('push-message').value = '';
-            
-            document.getElementById('app-operation-result').innerHTML = 
-              `<div class="text-green-400"><i class="fas fa-check mr-2"></i>Push notification queued for ${platform}. Users will receive it shortly.</div>`;
-            showToast('Push notification sent!');
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          } catch(e) {
-            console.error('Failed to send push notification:', e);
-            showToast('Failed to send push notification', 'error');
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          }
-        }
-        
-        async function loadVersionConfig() {
-          try {
-            const btn = document.getElementById('load-version-config-btn');
-            if (btn) {
-              btn.disabled = true;
-              btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Loading...';
-            }
-            
-            const { getFirestore, doc, getDoc, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            // Load Android config
-            const androidDoc = await getDoc(doc(db, 'app_config', 'android_version'));
-            if (androidDoc.exists()) {
-              const data = androidDoc.data();
-              document.getElementById('android-latest-version').value = data.latest_version || '';
-              document.getElementById('android-min-version').value = data.minimum_version || '';
-              document.getElementById('android-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('android-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('android-latest-version').value = '';
-              document.getElementById('android-min-version').value = '';
-              const vEl = document.getElementById('android-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load iOS config
-            const iosDoc = await getDoc(doc(db, 'app_config', 'ios_version'));
-            if (iosDoc.exists()) {
-              const data = iosDoc.data();
-              document.getElementById('ios-latest-version').value = data.latest_version || '';
-              document.getElementById('ios-min-version').value = data.minimum_version || '';
-              document.getElementById('ios-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('ios-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('ios-latest-version').value = '';
-              document.getElementById('ios-min-version').value = '';
-              const vEl = document.getElementById('ios-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load version distribution from app_usage collection
-            await loadVersionDistribution();
-            
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-            
-            showToast('Version config loaded');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>Version configuration loaded successfully</div>';
-          } catch(e) {
-            console.error('Failed to load version config:', e);
-            showToast('Failed to load version config', 'error');
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-          }
-        }
-        
-        async function saveVersionConfig() {
-          try {
-            const role = await getUserRole();
-            if (role !== 'admin') {
-              showToast('You need to be an admin to manage app versions', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Saving...';
-            
-            const { getFirestore, doc, setDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || 0;
-            const androidMin = parseInt(document.getElementById('android-min-version').value) || 0;
-            const androidMessage = document.getElementById('android-update-message').value;
-            
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || 0;
-            const iosMin = parseInt(document.getElementById('ios-min-version').value) || 0;
-            const iosMessage = document.getElementById('ios-update-message').value;
-            
-            // Save Android config
-            await setDoc(doc(db, 'app_config', 'android_version'), {
-              latest_version: androidLatest,
-              minimum_version: androidMin,
-              update_message: androidMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            // Save iOS config
-            await setDoc(doc(db, 'app_config', 'ios_version'), {
-              latest_version: iosLatest,
-              minimum_version: iosMin,
-              update_message: iosMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            showToast('Version config saved successfully');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App version config updated. Users will be prompted on next app launch.</div>';
-            document.getElementById('android-version').textContent = `v${androidLatest} (min v${androidMin})`;
-            document.getElementById('ios-version').textContent = `v${iosLatest} (min v${iosMin})`;
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          } catch(e) {
-            console.error('Failed to save version config:', e);
-            showToast('Failed to save version config', 'error');
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          }
-        }
-        
-        async function loadVersionDistribution() {
-          try {
-            const { getFirestore, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            const androidVersions = {};
-            const iosVersions = {};
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || null;
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || null;
-            
-            usageSnap.forEach(doc => {
-              const data = doc.data();
-              const platform = data.platform;
-              const version = data.app_version;
-              
-              if (platform === 'android' && version) {
-                androidVersions[version] = (androidVersions[version] || 0) + 1;
-              } else if (platform === 'ios' && version) {
-                iosVersions[version] = (iosVersions[version] || 0) + 1;
-              }
-            });
-            
-            // Display Android distribution
-            const androidDiv = document.getElementById('android-version-distribution');
-            if (Object.keys(androidVersions).length === 0) {
-              androidDiv.innerHTML = androidLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-green-400 font-medium">v${androidLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const androidTotal = Object.values(androidVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(androidVersions).sort((a, b) => b[1] - a[1]);
-              androidDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / androidTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-green-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-            
-            // Display iOS distribution
-            const iosDiv = document.getElementById('ios-version-distribution');
-            if (Object.keys(iosVersions).length === 0) {
-              iosDiv.innerHTML = iosLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-blue-400 font-medium">v${iosLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const iosTotal = Object.values(iosVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(iosVersions).sort((a, b) => b[1] - a[1]);
-              iosDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / iosTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-blue-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-          } catch(e) {
-            console.error('Failed to load version distribution:', e);
-            document.getElementById('android-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-            document.getElementById('ios-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-          }
-        }
-        
-        async function viewCrashReports() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading error telemetry...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const cutoff = Timestamp.fromDate(new Date(Date.now() - 7 * 86400000));
-
-            const isErr = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            let rows = [];
-            try {
-              const snap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              const snap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            }
-
-            const inWin = (v) => {
-              try {
-                const ts = v.serverTimestamp?.toMillis ? v.serverTimestamp.toMillis() : null;
-                return ts !== null && ts >= (Date.now() - 7 * 86400000);
-              } catch (_) {
-                return true;
-              }
-            };
-
-            const filtered = rows.filter((v) => isErr(v) && inWin(v));
-            let android = 0;
-            let ios = 0;
-            let web = 0;
-            const samples = [];
-            filtered.forEach((v) => {
-              const ua = v.userAgent || '';
-              if (__isAndroidAppUserAgent(ua)) android += 1;
-              else if (__isIosAppUserAgent(ua)) ios += 1;
-              else web += 1;
-              const msg = (v.message || v.error || '').toString().slice(0, 160);
-              if (msg && samples.length < 6) samples.push(msg);
-            });
-
-            const sampleHtml = samples.length
-              ? `<div class="text-slate-400 text-xs mt-2"><div class="text-slate-300 font-semibold mb-1">Recent samples</div><ul class="list-disc pl-5 space-y-1">${samples.map((m) => `<li>${m}</li>`).join('')}</ul></div>`
-              : '';
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">Client errors (7 days)</div>
-                  <div class="text-slate-500 text-[11px]">This is JavaScript / WebView telemetry from <span class="text-slate-300">client_logs</span>, not native Crashlytics.</div>
-                  <div class="text-slate-300 text-xs">Android WebView: <span class="text-yellow-300 font-medium">${android}</span></div>
-                  <div class="text-slate-300 text-xs">iOS WebView: <span class="text-yellow-300 font-medium">${ios}</span></div>
-                  <div class="text-slate-300 text-xs">Other / web: <span class="text-yellow-300 font-medium">${web}</span></div>
-                  ${sampleHtml}
-                </div>`;
-            }
-            showToast('Error telemetry loaded');
-          } catch (e) {
-            console.error('Crash report load failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load error telemetry</div>';
-            showToast('Failed to load crash reports', 'error');
-          }
-        }
-        
-        async function showAppAnalytics() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading in-app analytics...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(5000)));
-            const pageViews = pvSnap.docs.map((d) => d.data() || {});
-
-            const dayStart = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-            const today = dayStart(new Date());
-            const yday = today - 86400000;
-
-            const isAppPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              return __isAndroidAppUserAgent(ua) || __isIosAppUserAgent(ua) || String(url).includes('appassets.androidplatform.net');
-            };
-
-            const appPvs = pageViews.filter(isAppPv);
-
-            const visitorsToday = new Set();
-            const visitorsYesterday = new Set();
-            const sessionsToday = new Set();
-
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts) return;
-              const day = dayStart(ts);
-              const vid = v.visitorId || v.sessionId;
-              if (!vid) return;
-              if (day === today) {
-                visitorsToday.add(vid);
-                if (v.sessionId) sessionsToday.add(v.sessionId);
-              }
-              if (day === yday) visitorsYesterday.add(vid);
-            });
-
-            const dau = visitorsToday.size;
-            const yau = visitorsYesterday.size;
-            const dauNote = yau > 0 ? `${dau} today · ${yau} yesterday (unique visitor ids)` : `${dau} today (unique visitor ids)`;
-
-            const aeSnap = await getDocs(query(collection(db, 'analytics_events'), orderBy('timestamp', 'desc'), limit(5000)));
-            const events = aeSnap.docs.map((d) => d.data() || {});
-
-            const isAppEvent = (e) => __isAndroidAppUserAgent(e.userAgent || '') || __isIosAppUserAgent(e.userAgent || '');
-            const appEvents = events.filter(isAppEvent);
-
-            const sevenAgo = Date.now() - 7 * 86400000;
-            const recentAppEvents = appEvents.filter((e) => {
-              try {
-                const ts = e.timestamp?.toMillis ? e.timestamp.toMillis() : (e.timestamp?.toDate ? e.timestamp.toDate().getTime() : null);
-                return ts !== null && ts >= sevenAgo;
-              } catch (_) {
-                return true;
-              }
-            });
-
-            const engagements = recentAppEvents.filter((e) => e.event === 'page_engagement' && e.params && Number.isFinite(Number(e.params.duration_seconds)));
-            const avgEng = engagements.length
-              ? Math.round(engagements.reduce((s, e) => s + Number(e.params.duration_seconds || 0), 0) / engagements.length)
-              : null;
-
-            const featureCounts = {};
-            recentAppEvents.forEach((e) => {
-              const name = e.event || 'unknown';
-              if (name === 'page_engagement') return;
-              featureCounts[name] = (featureCounts[name] || 0) + 1;
-            });
-            const topFeature = Object.entries(featureCounts).sort((a, b) => b[1] - a[1])[0];
-
-            const byVisitorDays = {};
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts || !v.visitorId) return;
-              if (ts.getTime() < sevenAgo) return;
-              const dayKey = ts.toISOString().split('T')[0];
-              if (!byVisitorDays[v.visitorId]) byVisitorDays[v.visitorId] = new Set();
-              byVisitorDays[v.visitorId].add(dayKey);
-            });
-            const multiDayVisitors = Object.values(byVisitorDays).filter((s) => s.size >= 2).length;
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">In-app usage (Firestore telemetry)</div>
-                  <div class="text-slate-500 text-[11px]">Based on <span class="text-slate-300">page_views</span> + <span class="text-slate-300">analytics_events</span> from WebViews. This is not a substitute for Firebase Analytics retention reporting.</div>
-                  <div class="text-slate-300 text-sm">• Daily active visitors (app WebView): <span class="text-white font-medium">${dauNote}</span></div>
-                  <div class="text-slate-300 text-sm">• Avg engagement sample (7d): <span class="text-white font-medium">${avgEng == null ? 'N/A' : (avgEng + 's')}</span></div>
-                  <div class="text-slate-300 text-sm">• Multi-day visitors (7d, same visitor id): <span class="text-white font-medium">${multiDayVisitors}</span></div>
-                  <div class="text-slate-300 text-sm">• Top event (7d): <span class="text-white font-medium">${topFeature ? `${topFeature[0]} (${topFeature[1]})` : 'N/A'}</span></div>
-                </div>`;
-            }
-            showToast('Analytics loaded');
-          } catch (e) {
-            console.error('App analytics failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load analytics</div>';
-            showToast('Failed to load analytics', 'error');
-          }
         }
         
         // ===== REVENUE & MONETIZATION =====
@@ -11061,7 +10158,8 @@
           'assets/js/feature-flags.js',
           'assets/js/admin-modules/bulk-photo-import.js',
           'assets/js/admin-modules/fan-passport.js',
-          'assets/js/admin-modules/quick-composer.js'
+          'assets/js/admin-modules/quick-composer.js',
+          'assets/js/admin-modules/console-enhancements.js'
         ];
         window.RR.adminAuthReady.then(function () {
           function loadNext(i) {

--- a/android/app/src/main/assets/www/admin-console.html
+++ b/android/app/src/main/assets/www/admin-console.html
@@ -1232,7 +1232,7 @@
                     Command <span class="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 via-amber-300 to-rose-400">Center</span>
                   </h1>
                   <p class="text-slate-400 text-sm md:text-base leading-relaxed max-w-xl">
-                    Approvals, race content, analytics, and ops—one cockpit built for race-night speed.
+                    Approvals, race content, site banner, analytics, and ops—one cockpit built for race-night speed.
                   </p>
                   <div class="mt-4 flex flex-wrap items-center gap-2">
                     <span class="admin-hero-chip"><i class="fas fa-circle text-[0.45rem] opacity-80" aria-hidden="true"></i> Live console</span>
@@ -1316,7 +1316,47 @@
               </div>
             </div>
             
-            <!-- Next Race & Notes Row -->
+            <!-- Quick Actions -->
+            <div class="admin-card rounded-xl p-6">
+              <div class="flex items-center justify-between mb-4">
+                <h2 class="text-xl font-bold text-white">
+                  <i class="fas fa-bolt text-amber-400 mr-2"></i>
+                  Quick Actions
+                </h2>
+                <span class="text-xs text-slate-500">Jump to the jobs you do most</span>
+              </div>
+              <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3" id="overview-quick-actions">
+                <a href="#inbox" class="bg-slate-800/60 border border-slate-700/50 hover:border-cyan-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-inbox text-cyan-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Inbox</div>
+                </a>
+                <a href="#media" class="bg-slate-800/60 border border-slate-700/50 hover:border-purple-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-images text-purple-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Gallery</div>
+                </a>
+                <a href="#race" class="bg-slate-800/60 border border-slate-700/50 hover:border-yellow-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-flag-checkered text-yellow-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Results</div>
+                </a>
+                <a href="push-notifications.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-orange-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-bell text-orange-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Notify</div>
+                </a>
+                <a href="#schedule-mgmt" class="bg-slate-800/60 border border-slate-700/50 hover:border-green-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-calendar-alt text-green-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Schedule</div>
+                </a>
+                <a href="live-race-admin.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-red-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-broadcast-tower text-red-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Go Live</div>
+                </a>
+              </div>
+            </div>
+
+            <!-- Overview tools mount (site banner, staff notes, attention digest) -->
+            <div id="overview-tools" class="grid grid-cols-1 lg:grid-cols-2 gap-6"></div>
+
+                        <!-- Next Race & Notes Row -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <!-- Next Race Countdown -->
               <div class="admin-card rounded-xl p-6">
@@ -2440,187 +2480,6 @@
                 <div id="backup-operation-result" class="mt-3 text-sm text-slate-300"></div>
               </div>
 
-              <!-- Mobile App Management -->
-              <div class="admin-card rounded-xl p-6">
-                <h3 class="text-xl font-bold text-white mb-4">
-                  <i class="fas fa-mobile-alt text-cyan-400 mr-2"></i>
-                  Mobile App Management
-                </h3>
-                <p class="text-slate-400 text-sm mb-4">Monitor your Android and iOS apps</p>
-                
-                <!-- App Stats -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                  <!-- Android -->
-                  <div class="bg-gradient-to-br from-green-900/30 to-slate-800/30 border border-green-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-android text-green-400 mr-2 text-xl"></i>Android App
-                      </h4>
-                      <span id="android-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="android-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-green-400 font-medium" id="android-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="android-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="android-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- iOS -->
-                  <div class="bg-gradient-to-br from-blue-900/30 to-slate-800/30 border border-blue-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-apple text-blue-400 mr-2 text-xl"></i>iOS App
-                      </h4>
-                      <span id="ios-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="ios-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-blue-400 font-medium" id="ios-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="ios-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="ios-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
-                <!-- App Version Management -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">App Version Management</h4>
-                  
-                  <!-- Version Distribution Stats -->
-                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">Android Version Distribution</h5>
-                      <div id="android-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">iOS Version Distribution</h5>
-                      <div id="ios-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- Android Version Config -->
-                  <div class="bg-slate-900/50 border border-green-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-android text-green-400 mr-2"></i>Android Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="android-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="android-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="android-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <!-- iOS Version Config -->
-                  <div class="bg-slate-900/50 border border-blue-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-apple text-blue-400 mr-2"></i>iOS Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="ios-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="ios-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="ios-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <div class="flex justify-end space-x-2">
-                    <button id="load-version-config-btn" class="modern-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-sync mr-2"></i>Load Current
-                    </button>
-                    <button id="save-version-config-btn" class="success-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-save mr-2"></i>Save Config
-                    </button>
-                  </div>
-                </div>
-                
-                <!-- Push Notifications -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">Send Push Notification</h4>
-                  <div class="space-y-3">
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Platform</label>
-                      <select id="push-platform" class="modern-input w-full p-2 text-white">
-                        <option value="both">Both (Android + iOS)</option>
-                        <option value="android">Android Only</option>
-                        <option value="ios">iOS Only</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Title</label>
-                      <input type="text" id="push-title" class="modern-input w-full p-2 text-white" placeholder="Race Alert!" />
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Message</label>
-                      <textarea id="push-message" rows="2" class="modern-input w-full p-2 text-white resize-none" placeholder="Next race starts in 1 hour!"></textarea>
-                    </div>
-                  </div>
-                  <div class="mt-4 flex justify-end">
-                    <button id="send-push-notification-btn" class="success-btn text-white px-4 py-2 rounded text-sm">
-                      <i class="fas fa-bell mr-2"></i>Send Notification
-                    </button>
-                  </div>
-                </div>
-                
-                <div class="flex flex-wrap gap-2">
-                  <button id="refresh-app-stats-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-sync mr-2"></i>Refresh Stats
-                  </button>
-                  <button id="view-crash-reports-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-bug mr-2"></i>View Crash Reports
-                  </button>
-                  <button id="app-analytics-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-chart-bar mr-2"></i>App Analytics
-                  </button>
-                </div>
-                <div id="app-operation-result" class="mt-3 text-sm text-slate-300"></div>
-              </div>
-
               <!-- Revenue & Monetization -->
               <div class="admin-card rounded-xl p-6">
                 <h3 class="text-xl font-bold text-white mb-4">
@@ -3217,7 +3076,7 @@
                     <i class="fas fa-heartbeat text-red-400 mr-3"></i>
                     Site Health Dashboard
                   </h2>
-                  <p class="text-slate-400 text-sm mt-1">Monitor app versions, system status, and error rates</p>
+                  <p class="text-slate-400 text-sm mt-1">Monitor site status, system health, and error rates</p>
                 </div>
                 <div class="flex items-center space-x-3">
                   <span class="text-slate-500 text-xs" id="health-last-check"></span>
@@ -3227,25 +3086,9 @@
                 </div>
               </div>
 
-              <!-- App Versions -->
-              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-mobile-alt text-blue-400 mr-2"></i>App Versions</h3>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-android text-green-400 text-xl"></i>
-                    <span class="text-white font-semibold">Android</span>
-                  </div>
-                  <div class="text-2xl font-bold text-green-400" id="health-android-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-android-code">Build --</div>
-                </div>
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-apple text-slate-300 text-xl"></i>
-                    <span class="text-white font-semibold">iOS</span>
-                  </div>
-                  <div class="text-2xl font-bold text-slate-300" id="health-ios-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-ios-code">Build --</div>
-                </div>
+              <!-- Site Version -->
+              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-globe text-blue-400 mr-2"></i>Site Version</h3>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                 <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
                   <div class="flex items-center space-x-3 mb-2">
                     <i class="fas fa-globe text-blue-400 text-xl"></i>
@@ -3253,6 +3096,14 @@
                   </div>
                   <div class="text-2xl font-bold text-blue-400" id="health-web-ver">--</div>
                   <div class="text-xs text-slate-500" id="health-web-url">redsracing.org</div>
+                </div>
+                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
+                  <div class="flex items-center space-x-3 mb-2">
+                    <i class="fas fa-bullhorn text-amber-400 text-xl"></i>
+                    <span class="text-white font-semibold">Public Banner</span>
+                  </div>
+                  <div class="text-lg font-semibold text-amber-300" id="health-banner-status">--</div>
+                  <div class="text-xs text-slate-500" id="health-banner-preview">Managed from Overview tools</div>
                 </div>
               </div>
 
@@ -5759,26 +5610,23 @@
             // Reset stat values to show loading
             ['health-errors-24h','health-errors-7d','health-subscribers'].forEach(id => el(id, '...'));
             el('health-top-error-page', '...');
-            // ---- App versions from app_config (replaces hardcoded values) ----
-            try {
-              const androidCfg = await getDoc(doc(db, 'app_config', 'android_version'));
-              if (androidCfg.exists()) {
-                const d = androidCfg.data();
-                el('health-android-ver', d.version_name || d.latest_version || '?');
-                el('health-android-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-android-ver', 'No config'); el('health-android-code', '--'); }
-              const iosCfg = await getDoc(doc(db, 'app_config', 'ios_version'));
-              if (iosCfg.exists()) {
-                const d = iosCfg.data();
-                el('health-ios-ver', d.version_name || d.latest_version || '?');
-                el('health-ios-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-ios-ver', 'No config'); el('health-ios-code', '--'); }
-            } catch(e) {
-              console.warn('Failed to read app_config versions:', e);
-              el('health-android-ver', '?'); el('health-android-code', '?');
-              el('health-ios-ver', '?'); el('health-ios-code', '?');
-            }
+            // ---- Site version + public banner status ----
             el('health-web-ver', document.querySelector('meta[name="app-version"]')?.content || 'live');
+            try {
+              const bannerCfg = await getDoc(doc(db, 'config', 'site_banner'));
+              if (bannerCfg.exists()) {
+                const d = bannerCfg.data() || {};
+                const on = !!d.enabled;
+                el('health-banner-status', on ? (d.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off');
+                el('health-banner-preview', (d.message || '').toString().slice(0, 80) || 'No message set');
+              } else {
+                el('health-banner-status', 'Off');
+                el('health-banner-preview', 'No banner configured');
+              }
+            } catch (e) {
+              el('health-banner-status', '?');
+              el('health-banner-preview', 'Could not load');
+            }
             // Firebase status
             const setStatus = (prefix, ok, msg) => {
               const dot = document.getElementById(prefix + '-dot');
@@ -7127,18 +6975,6 @@
         
         // ===== NEW ADMIN TOOLS FUNCTIONS =====
 
-        function __isAndroidAppUserAgent(ua) {
-          const s = String(ua || '').toLowerCase();
-          if (!s) return false;
-          return s.includes('android') && (s.includes('; wv') || s.includes('redsracingapp'));
-        }
-
-        function __isIosAppUserAgent(ua) {
-          const s = String(ua || '');
-          if (!s) return false;
-          return /iphone|ipad|ipod/i.test(s) && (s.includes('Mobile/') || s.includes('RedsRacingApp'));
-        }
-
         async function loadEmailMarketingStats() {
           const { getFirestore, collection, getDocs, query, orderBy, limit, getCountFromServer } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
           const app = await ensureDefaultApp();
@@ -7198,16 +7034,6 @@
             document.getElementById('backup-size').textContent = '0 KB';
             document.getElementById('backup-count').textContent = '0';
             
-            // Mobile App stats (versions come from app_config via loadVersionConfig)
-            document.getElementById('android-version').textContent = '--';
-            document.getElementById('ios-version').textContent = '--';
-            document.getElementById('android-users').textContent = '--';
-            document.getElementById('ios-users').textContent = '--';
-            document.getElementById('android-crashes').textContent = '--';
-            document.getElementById('ios-crashes').textContent = '--';
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-            
             // Revenue stats
             document.getElementById('revenue-today').textContent = '$--';
             document.getElementById('revenue-month').textContent = '$--';
@@ -7224,12 +7050,6 @@
             
             // Load initial activity stats
             try { await refreshUserActivity(); } catch(e) { console.warn('Activity refresh failed:', e); }
-            // Load initial app stats
-            try { await refreshAppStats(); } catch(e) { console.warn('App stats refresh failed:', e); }
-            // Load configured app versions into cards + form
-            try { await loadVersionConfig(); } catch(e) { console.warn('Version config load failed:', e); }
-            // Load version distribution
-            try { await loadVersionDistribution(); } catch(e) { console.warn('Version distribution load failed:', e); }
             // Load initial revenue stats
             try { await refreshRevenueStats(); } catch(e) { console.warn('Revenue stats refresh failed:', e); }
           } catch(e) {
@@ -7348,25 +7168,6 @@
           
           const exportAllDataBtn = document.getElementById('export-all-data-btn');
           if (exportAllDataBtn) exportAllDataBtn.addEventListener('click', exportAllData);
-          
-          // Mobile App Management
-          const loadVersionConfigBtn = document.getElementById('load-version-config-btn');
-          if (loadVersionConfigBtn) loadVersionConfigBtn.addEventListener('click', loadVersionConfig);
-          
-          const saveVersionConfigBtn = document.getElementById('save-version-config-btn');
-          if (saveVersionConfigBtn) saveVersionConfigBtn.addEventListener('click', saveVersionConfig);
-          
-          const refreshAppStatsBtn = document.getElementById('refresh-app-stats-btn');
-          if (refreshAppStatsBtn) refreshAppStatsBtn.addEventListener('click', refreshAppStats);
-          
-          const sendPushNotificationBtn = document.getElementById('send-push-notification-btn');
-          if (sendPushNotificationBtn) sendPushNotificationBtn.addEventListener('click', sendPushNotification);
-          
-          const viewCrashReportsBtn = document.getElementById('view-crash-reports-btn');
-          if (viewCrashReportsBtn) viewCrashReportsBtn.addEventListener('click', viewCrashReports);
-          
-          const appAnalyticsBtn = document.getElementById('app-analytics-btn');
-          if (appAnalyticsBtn) appAnalyticsBtn.addEventListener('click', showAppAnalytics);
           
           // Revenue & Monetization
           const refreshRevenueBtn = document.getElementById('refresh-revenue-btn');
@@ -8816,710 +8617,6 @@
           const simple = s.match(/\d+\.\d+/);
           if (simple && simple[0]) return simple[0];
           return '';
-        }
-        
-        async function refreshAppStats() {
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const msDay = 86400000;
-            const cutoff7d = Timestamp.fromDate(new Date(Date.now() - 7 * msDay));
-
-            const toMillis = (ts) => {
-              try {
-                if (!ts) return null;
-                if (ts.toMillis) return ts.toMillis();
-                const d = ts.toDate ? ts.toDate() : new Date(ts);
-                const n = d.getTime();
-                return Number.isFinite(n) ? n : null;
-              } catch (_) {
-                return null;
-              }
-            };
-
-            // --- Real install / activity signals from app_usage (FCM token doc IDs) ---
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            let androidTotal = 0;
-            let iosTotal = 0;
-            let androidSeen7d = 0;
-            let iosSeen7d = 0;
-            let androidLatestSeen = null;
-            let iosLatestSeen = null;
-            let androidLatestName = '';
-            let iosLatestName = '';
-
-            usageSnap.forEach((docSnap) => {
-              const d = docSnap.data() || {};
-              const platform = String(d.platform || '').toLowerCase();
-              const lastMs = toMillis(d.last_seen) ?? toMillis(d.lastSeen);
-              const seenRecently = lastMs !== null && lastMs >= (Date.now() - 7 * msDay);
-
-              const parsed =
-                extractVersionCode(d.app_version_code) ??
-                extractVersionCode(d.versionCode) ??
-                extractVersionCode(d.build) ??
-                extractVersionCode(d.app_version) ??
-                extractVersionCode(d.version) ??
-                extractVersionCode(d.appVersion);
-              const parsedName =
-                extractVersionName(d.app_version_name) ||
-                extractVersionName(d.versionName) ||
-                extractVersionName(d.app_version) ||
-                extractVersionName(d.version) ||
-                extractVersionName(d.appVersion);
-
-              if (platform === 'android') {
-                androidTotal += 1;
-                if (seenRecently) androidSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  androidLatestSeen = androidLatestSeen === null ? parsed : Math.max(androidLatestSeen, parsed);
-                  if (parsedName) androidLatestName = parsedName;
-                } else if (parsedName) {
-                  androidLatestName = parsedName;
-                }
-              } else if (platform === 'ios') {
-                iosTotal += 1;
-                if (seenRecently) iosSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  iosLatestSeen = iosLatestSeen === null ? parsed : Math.max(iosLatestSeen, parsed);
-                  if (parsedName) iosLatestName = parsedName;
-                } else if (parsedName) {
-                  iosLatestName = parsedName;
-                }
-              }
-            });
-
-            const androidUsersEl = document.getElementById('android-users');
-            const iosUsersEl = document.getElementById('ios-users');
-            if (androidUsersEl) androidUsersEl.textContent = androidTotal ? `${androidSeen7d} / ${androidTotal}` : '--';
-            if (iosUsersEl) iosUsersEl.textContent = iosTotal ? `${iosSeen7d} / ${iosTotal}` : '--';
-
-            // --- WebView JS error rate (7d): client_logs errors vs page_views in app WebViews ---
-            const isTrackedError = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            const classifyPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              if (__isAndroidAppUserAgent(ua)) return 'android';
-              if (__isIosAppUserAgent(ua)) return 'ios';
-              if (String(url).includes('appassets.androidplatform.net')) return 'android';
-              return null;
-            };
-
-            let logs = [];
-            try {
-              const logSnap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff7d), orderBy('serverTimestamp', 'desc'), limit(1500)));
-              logs = logSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const logSnap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(1500)));
-                logs = logSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                logs = [];
-              }
-            }
-
-            let pv = [];
-            try {
-              const pvSnap = await getDocs(query(collection(db, 'page_views'), where('timestamp', '>=', cutoff7d), orderBy('timestamp', 'desc'), limit(4000)));
-              pv = pvSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(4000)));
-                pv = pvSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                pv = [];
-              }
-            }
-
-            const cutoffMs = Date.now() - 7 * msDay;
-            const logInWindow = (v) => {
-              const ms = toMillis(v.serverTimestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-            const pvInWindow = (v) => {
-              const ms = toMillis(v.timestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-
-            const logsW = logs.filter(logInWindow);
-            const pvW = pv.filter(pvInWindow);
-
-            const errAndroid = logsW.filter((v) => isTrackedError(v) && __isAndroidAppUserAgent(v.userAgent)).length;
-            const errIos = logsW.filter((v) => isTrackedError(v) && __isIosAppUserAgent(v.userAgent)).length;
-            const pvAndroid = pvW.filter((v) => classifyPv(v) === 'android').length;
-            const pvIos = pvW.filter((v) => classifyPv(v) === 'ios').length;
-
-            const fmtRate = (errs, views) => {
-              if (!views) return 'N/A';
-              return `${((errs / views) * 100).toFixed(2)}%`;
-            };
-
-            const androidCrashEl = document.getElementById('android-crashes');
-            const iosCrashEl = document.getElementById('ios-crashes');
-            if (androidCrashEl) androidCrashEl.textContent = fmtRate(errAndroid, pvAndroid);
-            if (iosCrashEl) iosCrashEl.textContent = fmtRate(errIos, pvIos);
-
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-
-            // Use config minimums if available (for display only)
-            const androidMin = parseInt(document.getElementById('android-min-version')?.value, 10);
-            const iosMin = parseInt(document.getElementById('ios-min-version')?.value, 10);
-
-            if (androidLatestSeen !== null || androidLatestName) {
-              const codePart = Number.isFinite(androidLatestSeen) ? androidLatestSeen : '';
-              const namePart = androidLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(androidMin) && codePart !== '') {
-                label = `${label} · min ${androidMin}`;
-              }
-              document.getElementById('android-version').textContent = label;
-            }
-            if (iosLatestSeen !== null || iosLatestName) {
-              const codePart = Number.isFinite(iosLatestSeen) ? iosLatestSeen : '';
-              const namePart = iosLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(iosMin) && codePart !== '') {
-                label = `${label} · min ${iosMin}`;
-              }
-              document.getElementById('ios-version').textContent = label;
-            }
-
-            // Real status badges based on whether we've seen recent traffic
-            // from the platform (last 7 days of page_views with the matching
-            // user-agent). Replaces the always-on hardcoded "Live" labels.
-            const androidBadge = document.getElementById('android-status-badge');
-            const iosBadge = document.getElementById('ios-status-badge');
-            if (androidBadge) {
-              const seen = parseInt(document.getElementById('android-users')?.textContent || '0', 10) > 0;
-              androidBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              androidBadge.className = `px-2 py-1 ${seen ? 'bg-green-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-            if (iosBadge) {
-              const seen = parseInt(document.getElementById('ios-users')?.textContent || '0', 10) > 0;
-              iosBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              iosBadge.className = `px-2 py-1 ${seen ? 'bg-blue-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App stats refreshed from <span class="text-slate-200">app_usage</span>, <span class="text-slate-200">page_views</span>, and <span class="text-slate-200">client_logs</span></div>';
-            showToast('App stats refreshed');
-          } catch(e) {
-            console.error('Failed to refresh app stats:', e);
-            showToast('Failed to refresh app stats', 'error');
-          }
-        }
-        
-        async function sendPushNotification() {
-          try {
-            console.log('[Push Notification] Checking user role...');
-            const role = await getUserRole();
-            console.log('[Push Notification] User role:', role);
-            
-            if (!role) {
-              console.error('[Push Notification] No role found - user may not be authenticated');
-              showToast('Please log in to send push notifications', 'error');
-              return;
-            }
-            
-            if (!isModeratorRole(role)) {
-              console.warn('[Push Notification] User role insufficient:', role);
-              showToast(`You need to be a team-member or admin to send push notifications (current role: ${role})`, 'error');
-              return;
-            }
-            
-            console.log('[Push Notification] Role check passed:', role);
-            
-            const platform = document.getElementById('push-platform').value;
-            const title = document.getElementById('push-title').value;
-            const message = document.getElementById('push-message').value;
-            
-            if (!title || !message) {
-              showToast('Please fill in title and message', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Sending...';
-            
-            const { getFirestore, collection, addDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            // Store notification in Firestore for Cloud Function to send
-            try {
-              const notificationData = {
-                platform,
-                title,
-                message,
-                timestamp: serverTimestamp(),
-                sentBy: auth.currentUser?.uid || null,
-                status: 'pending'
-              };
-              
-              await addDoc(collection(db, 'push_notifications'), notificationData);
-              
-              // Also log to admin logs
-              await addDoc(collection(db, 'admin_logs'), {
-                action: 'push_notification_sent',
-                platform,
-                title,
-                message: message.substring(0, 100),
-                timestamp: serverTimestamp(),
-                uid: auth.currentUser?.uid || null,
-                role: role || 'unknown'
-              });
-            } catch(error) {
-              console.error('Failed to queue push notification:', error);
-              throw error;
-            }
-            
-            // Clear form
-            document.getElementById('push-title').value = '';
-            document.getElementById('push-message').value = '';
-            
-            document.getElementById('app-operation-result').innerHTML = 
-              `<div class="text-green-400"><i class="fas fa-check mr-2"></i>Push notification queued for ${platform}. Users will receive it shortly.</div>`;
-            showToast('Push notification sent!');
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          } catch(e) {
-            console.error('Failed to send push notification:', e);
-            showToast('Failed to send push notification', 'error');
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          }
-        }
-        
-        async function loadVersionConfig() {
-          try {
-            const btn = document.getElementById('load-version-config-btn');
-            if (btn) {
-              btn.disabled = true;
-              btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Loading...';
-            }
-            
-            const { getFirestore, doc, getDoc, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            // Load Android config
-            const androidDoc = await getDoc(doc(db, 'app_config', 'android_version'));
-            if (androidDoc.exists()) {
-              const data = androidDoc.data();
-              document.getElementById('android-latest-version').value = data.latest_version || '';
-              document.getElementById('android-min-version').value = data.minimum_version || '';
-              document.getElementById('android-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('android-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('android-latest-version').value = '';
-              document.getElementById('android-min-version').value = '';
-              const vEl = document.getElementById('android-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load iOS config
-            const iosDoc = await getDoc(doc(db, 'app_config', 'ios_version'));
-            if (iosDoc.exists()) {
-              const data = iosDoc.data();
-              document.getElementById('ios-latest-version').value = data.latest_version || '';
-              document.getElementById('ios-min-version').value = data.minimum_version || '';
-              document.getElementById('ios-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('ios-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('ios-latest-version').value = '';
-              document.getElementById('ios-min-version').value = '';
-              const vEl = document.getElementById('ios-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load version distribution from app_usage collection
-            await loadVersionDistribution();
-            
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-            
-            showToast('Version config loaded');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>Version configuration loaded successfully</div>';
-          } catch(e) {
-            console.error('Failed to load version config:', e);
-            showToast('Failed to load version config', 'error');
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-          }
-        }
-        
-        async function saveVersionConfig() {
-          try {
-            const role = await getUserRole();
-            if (role !== 'admin') {
-              showToast('You need to be an admin to manage app versions', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Saving...';
-            
-            const { getFirestore, doc, setDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || 0;
-            const androidMin = parseInt(document.getElementById('android-min-version').value) || 0;
-            const androidMessage = document.getElementById('android-update-message').value;
-            
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || 0;
-            const iosMin = parseInt(document.getElementById('ios-min-version').value) || 0;
-            const iosMessage = document.getElementById('ios-update-message').value;
-            
-            // Save Android config
-            await setDoc(doc(db, 'app_config', 'android_version'), {
-              latest_version: androidLatest,
-              minimum_version: androidMin,
-              update_message: androidMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            // Save iOS config
-            await setDoc(doc(db, 'app_config', 'ios_version'), {
-              latest_version: iosLatest,
-              minimum_version: iosMin,
-              update_message: iosMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            showToast('Version config saved successfully');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App version config updated. Users will be prompted on next app launch.</div>';
-            document.getElementById('android-version').textContent = `v${androidLatest} (min v${androidMin})`;
-            document.getElementById('ios-version').textContent = `v${iosLatest} (min v${iosMin})`;
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          } catch(e) {
-            console.error('Failed to save version config:', e);
-            showToast('Failed to save version config', 'error');
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          }
-        }
-        
-        async function loadVersionDistribution() {
-          try {
-            const { getFirestore, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            const androidVersions = {};
-            const iosVersions = {};
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || null;
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || null;
-            
-            usageSnap.forEach(doc => {
-              const data = doc.data();
-              const platform = data.platform;
-              const version = data.app_version;
-              
-              if (platform === 'android' && version) {
-                androidVersions[version] = (androidVersions[version] || 0) + 1;
-              } else if (platform === 'ios' && version) {
-                iosVersions[version] = (iosVersions[version] || 0) + 1;
-              }
-            });
-            
-            // Display Android distribution
-            const androidDiv = document.getElementById('android-version-distribution');
-            if (Object.keys(androidVersions).length === 0) {
-              androidDiv.innerHTML = androidLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-green-400 font-medium">v${androidLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const androidTotal = Object.values(androidVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(androidVersions).sort((a, b) => b[1] - a[1]);
-              androidDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / androidTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-green-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-            
-            // Display iOS distribution
-            const iosDiv = document.getElementById('ios-version-distribution');
-            if (Object.keys(iosVersions).length === 0) {
-              iosDiv.innerHTML = iosLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-blue-400 font-medium">v${iosLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const iosTotal = Object.values(iosVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(iosVersions).sort((a, b) => b[1] - a[1]);
-              iosDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / iosTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-blue-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-          } catch(e) {
-            console.error('Failed to load version distribution:', e);
-            document.getElementById('android-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-            document.getElementById('ios-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-          }
-        }
-        
-        async function viewCrashReports() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading error telemetry...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const cutoff = Timestamp.fromDate(new Date(Date.now() - 7 * 86400000));
-
-            const isErr = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            let rows = [];
-            try {
-              const snap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              const snap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            }
-
-            const inWin = (v) => {
-              try {
-                const ts = v.serverTimestamp?.toMillis ? v.serverTimestamp.toMillis() : null;
-                return ts !== null && ts >= (Date.now() - 7 * 86400000);
-              } catch (_) {
-                return true;
-              }
-            };
-
-            const filtered = rows.filter((v) => isErr(v) && inWin(v));
-            let android = 0;
-            let ios = 0;
-            let web = 0;
-            const samples = [];
-            filtered.forEach((v) => {
-              const ua = v.userAgent || '';
-              if (__isAndroidAppUserAgent(ua)) android += 1;
-              else if (__isIosAppUserAgent(ua)) ios += 1;
-              else web += 1;
-              const msg = (v.message || v.error || '').toString().slice(0, 160);
-              if (msg && samples.length < 6) samples.push(msg);
-            });
-
-            const sampleHtml = samples.length
-              ? `<div class="text-slate-400 text-xs mt-2"><div class="text-slate-300 font-semibold mb-1">Recent samples</div><ul class="list-disc pl-5 space-y-1">${samples.map((m) => `<li>${m}</li>`).join('')}</ul></div>`
-              : '';
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">Client errors (7 days)</div>
-                  <div class="text-slate-500 text-[11px]">This is JavaScript / WebView telemetry from <span class="text-slate-300">client_logs</span>, not native Crashlytics.</div>
-                  <div class="text-slate-300 text-xs">Android WebView: <span class="text-yellow-300 font-medium">${android}</span></div>
-                  <div class="text-slate-300 text-xs">iOS WebView: <span class="text-yellow-300 font-medium">${ios}</span></div>
-                  <div class="text-slate-300 text-xs">Other / web: <span class="text-yellow-300 font-medium">${web}</span></div>
-                  ${sampleHtml}
-                </div>`;
-            }
-            showToast('Error telemetry loaded');
-          } catch (e) {
-            console.error('Crash report load failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load error telemetry</div>';
-            showToast('Failed to load crash reports', 'error');
-          }
-        }
-        
-        async function showAppAnalytics() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading in-app analytics...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(5000)));
-            const pageViews = pvSnap.docs.map((d) => d.data() || {});
-
-            const dayStart = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-            const today = dayStart(new Date());
-            const yday = today - 86400000;
-
-            const isAppPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              return __isAndroidAppUserAgent(ua) || __isIosAppUserAgent(ua) || String(url).includes('appassets.androidplatform.net');
-            };
-
-            const appPvs = pageViews.filter(isAppPv);
-
-            const visitorsToday = new Set();
-            const visitorsYesterday = new Set();
-            const sessionsToday = new Set();
-
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts) return;
-              const day = dayStart(ts);
-              const vid = v.visitorId || v.sessionId;
-              if (!vid) return;
-              if (day === today) {
-                visitorsToday.add(vid);
-                if (v.sessionId) sessionsToday.add(v.sessionId);
-              }
-              if (day === yday) visitorsYesterday.add(vid);
-            });
-
-            const dau = visitorsToday.size;
-            const yau = visitorsYesterday.size;
-            const dauNote = yau > 0 ? `${dau} today · ${yau} yesterday (unique visitor ids)` : `${dau} today (unique visitor ids)`;
-
-            const aeSnap = await getDocs(query(collection(db, 'analytics_events'), orderBy('timestamp', 'desc'), limit(5000)));
-            const events = aeSnap.docs.map((d) => d.data() || {});
-
-            const isAppEvent = (e) => __isAndroidAppUserAgent(e.userAgent || '') || __isIosAppUserAgent(e.userAgent || '');
-            const appEvents = events.filter(isAppEvent);
-
-            const sevenAgo = Date.now() - 7 * 86400000;
-            const recentAppEvents = appEvents.filter((e) => {
-              try {
-                const ts = e.timestamp?.toMillis ? e.timestamp.toMillis() : (e.timestamp?.toDate ? e.timestamp.toDate().getTime() : null);
-                return ts !== null && ts >= sevenAgo;
-              } catch (_) {
-                return true;
-              }
-            });
-
-            const engagements = recentAppEvents.filter((e) => e.event === 'page_engagement' && e.params && Number.isFinite(Number(e.params.duration_seconds)));
-            const avgEng = engagements.length
-              ? Math.round(engagements.reduce((s, e) => s + Number(e.params.duration_seconds || 0), 0) / engagements.length)
-              : null;
-
-            const featureCounts = {};
-            recentAppEvents.forEach((e) => {
-              const name = e.event || 'unknown';
-              if (name === 'page_engagement') return;
-              featureCounts[name] = (featureCounts[name] || 0) + 1;
-            });
-            const topFeature = Object.entries(featureCounts).sort((a, b) => b[1] - a[1])[0];
-
-            const byVisitorDays = {};
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts || !v.visitorId) return;
-              if (ts.getTime() < sevenAgo) return;
-              const dayKey = ts.toISOString().split('T')[0];
-              if (!byVisitorDays[v.visitorId]) byVisitorDays[v.visitorId] = new Set();
-              byVisitorDays[v.visitorId].add(dayKey);
-            });
-            const multiDayVisitors = Object.values(byVisitorDays).filter((s) => s.size >= 2).length;
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">In-app usage (Firestore telemetry)</div>
-                  <div class="text-slate-500 text-[11px]">Based on <span class="text-slate-300">page_views</span> + <span class="text-slate-300">analytics_events</span> from WebViews. This is not a substitute for Firebase Analytics retention reporting.</div>
-                  <div class="text-slate-300 text-sm">• Daily active visitors (app WebView): <span class="text-white font-medium">${dauNote}</span></div>
-                  <div class="text-slate-300 text-sm">• Avg engagement sample (7d): <span class="text-white font-medium">${avgEng == null ? 'N/A' : (avgEng + 's')}</span></div>
-                  <div class="text-slate-300 text-sm">• Multi-day visitors (7d, same visitor id): <span class="text-white font-medium">${multiDayVisitors}</span></div>
-                  <div class="text-slate-300 text-sm">• Top event (7d): <span class="text-white font-medium">${topFeature ? `${topFeature[0]} (${topFeature[1]})` : 'N/A'}</span></div>
-                </div>`;
-            }
-            showToast('Analytics loaded');
-          } catch (e) {
-            console.error('App analytics failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load analytics</div>';
-            showToast('Failed to load analytics', 'error');
-          }
         }
         
         // ===== REVENUE & MONETIZATION =====
@@ -11061,7 +10158,8 @@
           'assets/js/feature-flags.js',
           'assets/js/admin-modules/bulk-photo-import.js',
           'assets/js/admin-modules/fan-passport.js',
-          'assets/js/admin-modules/quick-composer.js'
+          'assets/js/admin-modules/quick-composer.js',
+          'assets/js/admin-modules/console-enhancements.js'
         ];
         window.RR.adminAuthReady.then(function () {
           function loadNext(i) {

--- a/android/app/src/main/assets/www/assets/js/admin-modules/console-enhancements.js
+++ b/android/app/src/main/assets/www/assets/js/admin-modules/console-enhancements.js
@@ -1,0 +1,255 @@
+/**
+ * Admin console enhancements — Overview tools:
+ *  - Attention digest (pending work counts)
+ *  - Public site banner / maintenance mode
+ *  - Staff notes pad
+ */
+(function () {
+  'use strict';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function db() {
+    return window.firebase && window.firebase.firestore && window.firebase.firestore();
+  }
+
+  function toast(msg, type) {
+    if (typeof window.showToast === 'function') window.showToast(msg, type);
+  }
+
+  function init() {
+    var mount = document.getElementById('overview-tools');
+    if (!mount || mount.dataset.rrEnhanced === '1') return;
+    mount.dataset.rrEnhanced = '1';
+
+    mount.innerHTML =
+      '<div class="admin-card rounded-xl p-6">' +
+        '<div class="flex items-center justify-between mb-4">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-clipboard-list text-cyan-400 mr-2"></i>Needs Attention</h2>' +
+          '<button type="button" id="ce-attn-refresh" class="modern-btn text-white px-3 py-1.5 rounded text-xs"><i class="fas fa-sync mr-1"></i>Refresh</button>' +
+        '</div>' +
+        '<div id="ce-attn-list" class="space-y-2 text-sm"><div class="text-slate-500">Loading…</div></div>' +
+        '<a href="#inbox" class="inline-block mt-4 text-xs text-cyan-400 hover:text-cyan-300">Open full inbox →</a>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6">' +
+        '<h2 class="text-xl font-bold text-white mb-1"><i class="fas fa-bullhorn text-amber-400 mr-2"></i>Site Banner</h2>' +
+        '<p class="text-slate-400 text-xs mb-4">Show a public notice across the site. Use maintenance mode for race-night downtime.</p>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-enabled" class="rounded" /> Enable banner' +
+        '</label>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-maintenance" class="rounded" /> Maintenance mode (non-dismissible)' +
+        '</label>' +
+        '<label class="block text-xs text-slate-400 mb-1">Level</label>' +
+        '<select id="ce-banner-level" class="modern-input w-full p-2 text-white text-sm mb-3">' +
+          '<option value="info">Info</option>' +
+          '<option value="warn">Warning</option>' +
+          '<option value="urgent">Urgent</option>' +
+        '</select>' +
+        '<label class="block text-xs text-slate-400 mb-1">Message</label>' +
+        '<textarea id="ce-banner-message" rows="2" class="modern-input w-full p-2 text-white text-sm mb-3 resize-none" placeholder="Track day cancelled — new date TBA"></textarea>' +
+        '<div class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-3">' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Optional link URL</label>' +
+          '<input id="ce-banner-link" type="url" class="modern-input w-full p-2 text-white text-sm" placeholder="https://…" /></div>' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Link label</label>' +
+          '<input id="ce-banner-link-label" type="text" class="modern-input w-full p-2 text-white text-sm" placeholder="Details" /></div>' +
+        '</div>' +
+        '<button type="button" id="ce-banner-save" class="success-btn text-white px-4 py-2 rounded text-sm w-full">' +
+          '<i class="fas fa-save mr-2"></i>Save banner' +
+        '</button>' +
+        '<div id="ce-banner-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6" style="grid-column:1/-1;">' +
+        '<div class="flex items-center justify-between mb-3">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-sticky-note text-yellow-400 mr-2"></i>Staff Notes</h2>' +
+          '<span id="ce-notes-meta" class="text-xs text-slate-500"></span>' +
+        '</div>' +
+        '<p class="text-slate-400 text-xs mb-3">Shared scratchpad for the team — race-day reminders, passwords to rotate, open tasks.</p>' +
+        '<textarea id="ce-staff-notes" rows="5" class="modern-input w-full p-3 text-white text-sm mb-3 resize-y" placeholder="Write notes for other admins…"></textarea>' +
+        '<button type="button" id="ce-notes-save" class="modern-btn text-white px-4 py-2 rounded text-sm">' +
+          '<i class="fas fa-save mr-2"></i>Save notes' +
+        '</button>' +
+        '<div id="ce-notes-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>';
+
+    // Make the overview-tools grid span banner+attention on row 1, notes full width
+    mount.style.display = 'grid';
+    mount.style.gridTemplateColumns = 'repeat(auto-fit, minmax(300px, 1fr))';
+    mount.style.gap = '1.5rem';
+
+    document.getElementById('ce-attn-refresh').addEventListener('click', loadAttention);
+    document.getElementById('ce-banner-save').addEventListener('click', saveBanner);
+    document.getElementById('ce-notes-save').addEventListener('click', saveNotes);
+
+    loadAttention();
+    loadBanner();
+    loadNotes();
+  }
+
+  function loadAttention() {
+    var list = document.getElementById('ce-attn-list');
+    var firestore = db();
+    if (!list) return;
+    if (!firestore) {
+      list.innerHTML = '<div class="text-slate-500">Waiting for Firebase…</div>';
+      return setTimeout(loadAttention, 400);
+    }
+    list.innerHTML = '<div class="text-slate-500"><i class="fas fa-spinner fa-spin mr-2"></i>Checking queues…</div>';
+
+    var checks = [
+      { label: 'gallery photo(s)', href: '#media', icon: 'fa-images', color: 'text-purple-400',
+        run: function () { return firestore.collection('gallery_images').where('approved', '==', false).get(); } },
+      { label: 'fan wall post(s)', href: '#fanwall', icon: 'fa-bullhorn', color: 'text-orange-400',
+        run: function () { return firestore.collection('fan_wall').where('approved', '==', false).get(); } },
+      { label: 'Q&A item(s)', href: '#qna', icon: 'fa-comments', color: 'text-cyan-400',
+        run: function () { return firestore.collection('qna_submissions').where('status', '==', 'pending').get(); } },
+      { label: 'video(s)', href: '#videos', icon: 'fa-video', color: 'text-pink-400',
+        run: function () { return firestore.collection('jonny_videos').where('approved', '==', false).get(); } },
+      { label: 'failed push(es)', href: 'push-notifications.html', icon: 'fa-exclamation-circle', color: 'text-red-400',
+        run: function () { return firestore.collection('push_notifications').where('status', '==', 'failed').get(); } }
+    ];
+
+    Promise.all(checks.map(function (c) {
+      return c.run().then(function (snap) {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: snap.size };
+      }).catch(function () {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: null };
+      });
+    })).then(function (rows) {
+      var active = rows.filter(function (r) { return r.count && r.count > 0; });
+      if (!active.length) {
+        list.innerHTML = '<div class="text-green-400 flex items-center gap-2"><i class="fas fa-check-circle"></i> All clear — no pending queues</div>';
+        return;
+      }
+      list.innerHTML = active.map(function (r) {
+        return '<a href="' + esc(r.href) + '" class="flex items-center justify-between bg-slate-800/50 border border-slate-700/40 rounded-lg px-3 py-2 hover:border-slate-500/60 transition">' +
+          '<span class="text-slate-200"><i class="fas ' + r.icon + ' ' + r.color + ' mr-2"></i>' + esc(r.count + ' ' + r.label) + '</span>' +
+          '<i class="fas fa-chevron-right text-slate-500 text-xs"></i></a>';
+      }).join('');
+    });
+  }
+
+  function loadBanner() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadBanner, 400);
+    firestore.doc('config/site_banner').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var en = document.getElementById('ce-banner-enabled');
+      var mt = document.getElementById('ce-banner-maintenance');
+      var lv = document.getElementById('ce-banner-level');
+      var msg = document.getElementById('ce-banner-message');
+      var link = document.getElementById('ce-banner-link');
+      var lab = document.getElementById('ce-banner-link-label');
+      if (en) en.checked = !!d.enabled;
+      if (mt) mt.checked = !!d.maintenanceMode;
+      if (lv) lv.value = d.level === 'urgent' || d.level === 'warn' ? d.level : 'info';
+      if (msg) msg.value = d.message || '';
+      if (link) link.value = d.linkUrl || '';
+      if (lab) lab.value = d.linkLabel || '';
+    }).catch(function (e) {
+      console.warn('[console-enhancements] banner load', e);
+    });
+  }
+
+  function saveBanner() {
+    var firestore = db();
+    var status = document.getElementById('ce-banner-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var payload = {
+      enabled: !!(document.getElementById('ce-banner-enabled') || {}).checked,
+      maintenanceMode: !!(document.getElementById('ce-banner-maintenance') || {}).checked,
+      level: (document.getElementById('ce-banner-level') || {}).value || 'info',
+      message: ((document.getElementById('ce-banner-message') || {}).value || '').trim(),
+      linkUrl: ((document.getElementById('ce-banner-link') || {}).value || '').trim(),
+      linkLabel: ((document.getElementById('ce-banner-link-label') || {}).value || '').trim(),
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    };
+    if (payload.enabled && !payload.message) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Add a message before enabling.'; }
+      return;
+    }
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/site_banner').set(payload, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Banner saved. Public pages pick it up within a few seconds.'; }
+      toast('Site banner saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('site_banner.save', 'config/site_banner', { enabled: payload.enabled, maintenanceMode: payload.maintenanceMode }); } catch (_) {}
+      }
+      var hs = document.getElementById('health-banner-status');
+      var hp = document.getElementById('health-banner-preview');
+      if (hs) hs.textContent = payload.enabled ? (payload.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off';
+      if (hp) hp.textContent = payload.message ? payload.message.slice(0, 80) : 'No message set';
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save banner', 'error');
+    });
+  }
+
+  function loadNotes() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadNotes, 400);
+    firestore.doc('config/staff_notes').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var ta = document.getElementById('ce-staff-notes');
+      var meta = document.getElementById('ce-notes-meta');
+      if (ta) ta.value = d.notes || '';
+      if (meta) {
+        var when = d.updatedAt && d.updatedAt.toDate ? d.updatedAt.toDate().toLocaleString() : '';
+        meta.textContent = when ? ('Updated ' + when) : '';
+      }
+    }).catch(function (e) {
+      console.warn('[console-enhancements] notes load', e);
+    });
+  }
+
+  function saveNotes() {
+    var firestore = db();
+    var status = document.getElementById('ce-notes-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var notes = ((document.getElementById('ce-staff-notes') || {}).value || '');
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/staff_notes').set({
+      notes: notes,
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    }, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Notes saved.'; }
+      var meta = document.getElementById('ce-notes-meta');
+      if (meta) meta.textContent = 'Updated just now';
+      toast('Staff notes saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('staff_notes.save', 'config/staff_notes', { length: notes.length }); } catch (_) {}
+      }
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save notes', 'error');
+    });
+  }
+
+  // Prefer auth gate used by other admin modules; fall back to DOM ready.
+  function boot() {
+    if (window.RR && window.RR.adminAuthReady && typeof window.RR.adminAuthReady.then === 'function') {
+      window.RR.adminAuthReady.then(init);
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  }
+  boot();
+})();

--- a/android/app/src/main/assets/www/assets/js/navigation.js
+++ b/android/app/src/main/assets/www/assets/js/navigation.js
@@ -1056,6 +1056,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {

--- a/android/app/src/main/assets/www/assets/js/site-banner.js
+++ b/android/app/src/main/assets/www/assets/js/site-banner.js
@@ -1,0 +1,97 @@
+/**
+ * Public site banner — reads config/site_banner and shows a top strip.
+ * Fields: enabled, message, level (info|warn|urgent), maintenanceMode, linkUrl, linkLabel
+ */
+(function () {
+  'use strict';
+
+  var STYLE_ID = 'rr-site-banner-style';
+  var BAR_ID = 'rr-site-banner';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    var style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent =
+      '#' + BAR_ID + '{position:relative;z-index:9998;width:100%;padding:.7rem 1rem;text-align:center;font:600 .9rem/1.35 system-ui,sans-serif;}' +
+      '#' + BAR_ID + '[data-level="info"]{background:linear-gradient(90deg,#0f766e,#115e59);color:#ecfeff;}' +
+      '#' + BAR_ID + '[data-level="warn"]{background:linear-gradient(90deg,#b45309,#92400e);color:#fffbeb;}' +
+      '#' + BAR_ID + '[data-level="urgent"]{background:linear-gradient(90deg,#b91c1c,#7f1d1d);color:#fef2f2;}' +
+      '#' + BAR_ID + ' a{color:inherit;text-decoration:underline;margin-left:.5rem;}' +
+      '#' + BAR_ID + ' .rr-banner-close{position:absolute;right:.75rem;top:50%;transform:translateY(-50%);background:transparent;border:0;color:inherit;font-size:1.1rem;cursor:pointer;opacity:.8;}' +
+      'body.rr-maintenance #' + BAR_ID + '{position:sticky;top:0;}';
+    document.head.appendChild(style);
+  }
+
+  function dismissKey(message) {
+    return 'rr_banner_dismiss_' + String(message || '').slice(0, 80);
+  }
+
+  function render(data) {
+    if (!data || !data.enabled || !data.message) return;
+    try {
+      if (!data.maintenanceMode && sessionStorage.getItem(dismissKey(data.message)) === '1') return;
+    } catch (_) {}
+
+    ensureStyle();
+    var existing = document.getElementById(BAR_ID);
+    if (existing) existing.remove();
+
+    var level = data.level === 'urgent' || data.level === 'warn' ? data.level : 'info';
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.setAttribute('data-level', level);
+    bar.setAttribute('role', 'status');
+
+    var html = '<span>' + esc(data.message) + '</span>';
+    if (data.linkUrl) {
+      html += ' <a href="' + esc(data.linkUrl) + '">' + esc(data.linkLabel || 'Learn more') + '</a>';
+    }
+    if (!data.maintenanceMode) {
+      html += '<button type="button" class="rr-banner-close" aria-label="Dismiss">×</button>';
+    }
+    bar.innerHTML = html;
+
+    var closeBtn = bar.querySelector('.rr-banner-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        try { sessionStorage.setItem(dismissKey(data.message), '1'); } catch (_) {}
+        bar.remove();
+      });
+    }
+
+    document.body.insertBefore(bar, document.body.firstChild);
+    if (data.maintenanceMode) {
+      document.body.classList.add('rr-maintenance');
+    }
+  }
+
+  function tryLoad(attempt) {
+    attempt = attempt || 0;
+    try {
+      var path = (window.location.pathname || '').toLowerCase();
+      if (path.indexOf('admin-console') !== -1 || path.indexOf('setup-admin') !== -1) return;
+      var db = window._rrFirestore || (window.firebase && window.firebase.firestore && window.firebase.firestore());
+      if (!db) throw new Error('no db');
+      db.doc('config/site_banner').get().then(function (snap) {
+        if (snap && snap.exists) render(snap.data() || {});
+      }).catch(function () {});
+    } catch (_) {
+      if (attempt < 40) setTimeout(function () { tryLoad(attempt + 1); }, 250);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { tryLoad(0); });
+  } else {
+    tryLoad(0);
+  }
+})();

--- a/android/app/src/main/assets/www/index.html
+++ b/android/app/src/main/assets/www/index.html
@@ -917,6 +917,7 @@
       <meta name="twitter:image" content="/assets/img/og-default.jpg" />
       <script src="assets/js/page-meta.js" defer></script>
       <script src="assets/js/site-search.js" defer></script>
+      <script src="assets/js/site-banner.js" defer></script>
   </head>
   <body>
     <!-- Animated Background -->

--- a/android/app/src/main/assets/www/navigation.js
+++ b/android/app/src/main/assets/www/navigation.js
@@ -1057,6 +1057,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {

--- a/assets/js/admin-modules/console-enhancements.js
+++ b/assets/js/admin-modules/console-enhancements.js
@@ -1,0 +1,255 @@
+/**
+ * Admin console enhancements — Overview tools:
+ *  - Attention digest (pending work counts)
+ *  - Public site banner / maintenance mode
+ *  - Staff notes pad
+ */
+(function () {
+  'use strict';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function db() {
+    return window.firebase && window.firebase.firestore && window.firebase.firestore();
+  }
+
+  function toast(msg, type) {
+    if (typeof window.showToast === 'function') window.showToast(msg, type);
+  }
+
+  function init() {
+    var mount = document.getElementById('overview-tools');
+    if (!mount || mount.dataset.rrEnhanced === '1') return;
+    mount.dataset.rrEnhanced = '1';
+
+    mount.innerHTML =
+      '<div class="admin-card rounded-xl p-6">' +
+        '<div class="flex items-center justify-between mb-4">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-clipboard-list text-cyan-400 mr-2"></i>Needs Attention</h2>' +
+          '<button type="button" id="ce-attn-refresh" class="modern-btn text-white px-3 py-1.5 rounded text-xs"><i class="fas fa-sync mr-1"></i>Refresh</button>' +
+        '</div>' +
+        '<div id="ce-attn-list" class="space-y-2 text-sm"><div class="text-slate-500">Loading…</div></div>' +
+        '<a href="#inbox" class="inline-block mt-4 text-xs text-cyan-400 hover:text-cyan-300">Open full inbox →</a>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6">' +
+        '<h2 class="text-xl font-bold text-white mb-1"><i class="fas fa-bullhorn text-amber-400 mr-2"></i>Site Banner</h2>' +
+        '<p class="text-slate-400 text-xs mb-4">Show a public notice across the site. Use maintenance mode for race-night downtime.</p>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-enabled" class="rounded" /> Enable banner' +
+        '</label>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-maintenance" class="rounded" /> Maintenance mode (non-dismissible)' +
+        '</label>' +
+        '<label class="block text-xs text-slate-400 mb-1">Level</label>' +
+        '<select id="ce-banner-level" class="modern-input w-full p-2 text-white text-sm mb-3">' +
+          '<option value="info">Info</option>' +
+          '<option value="warn">Warning</option>' +
+          '<option value="urgent">Urgent</option>' +
+        '</select>' +
+        '<label class="block text-xs text-slate-400 mb-1">Message</label>' +
+        '<textarea id="ce-banner-message" rows="2" class="modern-input w-full p-2 text-white text-sm mb-3 resize-none" placeholder="Track day cancelled — new date TBA"></textarea>' +
+        '<div class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-3">' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Optional link URL</label>' +
+          '<input id="ce-banner-link" type="url" class="modern-input w-full p-2 text-white text-sm" placeholder="https://…" /></div>' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Link label</label>' +
+          '<input id="ce-banner-link-label" type="text" class="modern-input w-full p-2 text-white text-sm" placeholder="Details" /></div>' +
+        '</div>' +
+        '<button type="button" id="ce-banner-save" class="success-btn text-white px-4 py-2 rounded text-sm w-full">' +
+          '<i class="fas fa-save mr-2"></i>Save banner' +
+        '</button>' +
+        '<div id="ce-banner-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6" style="grid-column:1/-1;">' +
+        '<div class="flex items-center justify-between mb-3">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-sticky-note text-yellow-400 mr-2"></i>Staff Notes</h2>' +
+          '<span id="ce-notes-meta" class="text-xs text-slate-500"></span>' +
+        '</div>' +
+        '<p class="text-slate-400 text-xs mb-3">Shared scratchpad for the team — race-day reminders, passwords to rotate, open tasks.</p>' +
+        '<textarea id="ce-staff-notes" rows="5" class="modern-input w-full p-3 text-white text-sm mb-3 resize-y" placeholder="Write notes for other admins…"></textarea>' +
+        '<button type="button" id="ce-notes-save" class="modern-btn text-white px-4 py-2 rounded text-sm">' +
+          '<i class="fas fa-save mr-2"></i>Save notes' +
+        '</button>' +
+        '<div id="ce-notes-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>';
+
+    // Make the overview-tools grid span banner+attention on row 1, notes full width
+    mount.style.display = 'grid';
+    mount.style.gridTemplateColumns = 'repeat(auto-fit, minmax(300px, 1fr))';
+    mount.style.gap = '1.5rem';
+
+    document.getElementById('ce-attn-refresh').addEventListener('click', loadAttention);
+    document.getElementById('ce-banner-save').addEventListener('click', saveBanner);
+    document.getElementById('ce-notes-save').addEventListener('click', saveNotes);
+
+    loadAttention();
+    loadBanner();
+    loadNotes();
+  }
+
+  function loadAttention() {
+    var list = document.getElementById('ce-attn-list');
+    var firestore = db();
+    if (!list) return;
+    if (!firestore) {
+      list.innerHTML = '<div class="text-slate-500">Waiting for Firebase…</div>';
+      return setTimeout(loadAttention, 400);
+    }
+    list.innerHTML = '<div class="text-slate-500"><i class="fas fa-spinner fa-spin mr-2"></i>Checking queues…</div>';
+
+    var checks = [
+      { label: 'gallery photo(s)', href: '#media', icon: 'fa-images', color: 'text-purple-400',
+        run: function () { return firestore.collection('gallery_images').where('approved', '==', false).get(); } },
+      { label: 'fan wall post(s)', href: '#fanwall', icon: 'fa-bullhorn', color: 'text-orange-400',
+        run: function () { return firestore.collection('fan_wall').where('approved', '==', false).get(); } },
+      { label: 'Q&A item(s)', href: '#qna', icon: 'fa-comments', color: 'text-cyan-400',
+        run: function () { return firestore.collection('qna_submissions').where('status', '==', 'pending').get(); } },
+      { label: 'video(s)', href: '#videos', icon: 'fa-video', color: 'text-pink-400',
+        run: function () { return firestore.collection('jonny_videos').where('approved', '==', false).get(); } },
+      { label: 'failed push(es)', href: 'push-notifications.html', icon: 'fa-exclamation-circle', color: 'text-red-400',
+        run: function () { return firestore.collection('push_notifications').where('status', '==', 'failed').get(); } }
+    ];
+
+    Promise.all(checks.map(function (c) {
+      return c.run().then(function (snap) {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: snap.size };
+      }).catch(function () {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: null };
+      });
+    })).then(function (rows) {
+      var active = rows.filter(function (r) { return r.count && r.count > 0; });
+      if (!active.length) {
+        list.innerHTML = '<div class="text-green-400 flex items-center gap-2"><i class="fas fa-check-circle"></i> All clear — no pending queues</div>';
+        return;
+      }
+      list.innerHTML = active.map(function (r) {
+        return '<a href="' + esc(r.href) + '" class="flex items-center justify-between bg-slate-800/50 border border-slate-700/40 rounded-lg px-3 py-2 hover:border-slate-500/60 transition">' +
+          '<span class="text-slate-200"><i class="fas ' + r.icon + ' ' + r.color + ' mr-2"></i>' + esc(r.count + ' ' + r.label) + '</span>' +
+          '<i class="fas fa-chevron-right text-slate-500 text-xs"></i></a>';
+      }).join('');
+    });
+  }
+
+  function loadBanner() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadBanner, 400);
+    firestore.doc('config/site_banner').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var en = document.getElementById('ce-banner-enabled');
+      var mt = document.getElementById('ce-banner-maintenance');
+      var lv = document.getElementById('ce-banner-level');
+      var msg = document.getElementById('ce-banner-message');
+      var link = document.getElementById('ce-banner-link');
+      var lab = document.getElementById('ce-banner-link-label');
+      if (en) en.checked = !!d.enabled;
+      if (mt) mt.checked = !!d.maintenanceMode;
+      if (lv) lv.value = d.level === 'urgent' || d.level === 'warn' ? d.level : 'info';
+      if (msg) msg.value = d.message || '';
+      if (link) link.value = d.linkUrl || '';
+      if (lab) lab.value = d.linkLabel || '';
+    }).catch(function (e) {
+      console.warn('[console-enhancements] banner load', e);
+    });
+  }
+
+  function saveBanner() {
+    var firestore = db();
+    var status = document.getElementById('ce-banner-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var payload = {
+      enabled: !!(document.getElementById('ce-banner-enabled') || {}).checked,
+      maintenanceMode: !!(document.getElementById('ce-banner-maintenance') || {}).checked,
+      level: (document.getElementById('ce-banner-level') || {}).value || 'info',
+      message: ((document.getElementById('ce-banner-message') || {}).value || '').trim(),
+      linkUrl: ((document.getElementById('ce-banner-link') || {}).value || '').trim(),
+      linkLabel: ((document.getElementById('ce-banner-link-label') || {}).value || '').trim(),
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    };
+    if (payload.enabled && !payload.message) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Add a message before enabling.'; }
+      return;
+    }
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/site_banner').set(payload, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Banner saved. Public pages pick it up within a few seconds.'; }
+      toast('Site banner saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('site_banner.save', 'config/site_banner', { enabled: payload.enabled, maintenanceMode: payload.maintenanceMode }); } catch (_) {}
+      }
+      var hs = document.getElementById('health-banner-status');
+      var hp = document.getElementById('health-banner-preview');
+      if (hs) hs.textContent = payload.enabled ? (payload.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off';
+      if (hp) hp.textContent = payload.message ? payload.message.slice(0, 80) : 'No message set';
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save banner', 'error');
+    });
+  }
+
+  function loadNotes() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadNotes, 400);
+    firestore.doc('config/staff_notes').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var ta = document.getElementById('ce-staff-notes');
+      var meta = document.getElementById('ce-notes-meta');
+      if (ta) ta.value = d.notes || '';
+      if (meta) {
+        var when = d.updatedAt && d.updatedAt.toDate ? d.updatedAt.toDate().toLocaleString() : '';
+        meta.textContent = when ? ('Updated ' + when) : '';
+      }
+    }).catch(function (e) {
+      console.warn('[console-enhancements] notes load', e);
+    });
+  }
+
+  function saveNotes() {
+    var firestore = db();
+    var status = document.getElementById('ce-notes-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var notes = ((document.getElementById('ce-staff-notes') || {}).value || '');
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/staff_notes').set({
+      notes: notes,
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    }, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Notes saved.'; }
+      var meta = document.getElementById('ce-notes-meta');
+      if (meta) meta.textContent = 'Updated just now';
+      toast('Staff notes saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('staff_notes.save', 'config/staff_notes', { length: notes.length }); } catch (_) {}
+      }
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save notes', 'error');
+    });
+  }
+
+  // Prefer auth gate used by other admin modules; fall back to DOM ready.
+  function boot() {
+    if (window.RR && window.RR.adminAuthReady && typeof window.RR.adminAuthReady.then === 'function') {
+      window.RR.adminAuthReady.then(init);
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  }
+  boot();
+})();

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1056,6 +1056,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {

--- a/assets/js/site-banner.js
+++ b/assets/js/site-banner.js
@@ -1,0 +1,97 @@
+/**
+ * Public site banner — reads config/site_banner and shows a top strip.
+ * Fields: enabled, message, level (info|warn|urgent), maintenanceMode, linkUrl, linkLabel
+ */
+(function () {
+  'use strict';
+
+  var STYLE_ID = 'rr-site-banner-style';
+  var BAR_ID = 'rr-site-banner';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    var style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent =
+      '#' + BAR_ID + '{position:relative;z-index:9998;width:100%;padding:.7rem 1rem;text-align:center;font:600 .9rem/1.35 system-ui,sans-serif;}' +
+      '#' + BAR_ID + '[data-level="info"]{background:linear-gradient(90deg,#0f766e,#115e59);color:#ecfeff;}' +
+      '#' + BAR_ID + '[data-level="warn"]{background:linear-gradient(90deg,#b45309,#92400e);color:#fffbeb;}' +
+      '#' + BAR_ID + '[data-level="urgent"]{background:linear-gradient(90deg,#b91c1c,#7f1d1d);color:#fef2f2;}' +
+      '#' + BAR_ID + ' a{color:inherit;text-decoration:underline;margin-left:.5rem;}' +
+      '#' + BAR_ID + ' .rr-banner-close{position:absolute;right:.75rem;top:50%;transform:translateY(-50%);background:transparent;border:0;color:inherit;font-size:1.1rem;cursor:pointer;opacity:.8;}' +
+      'body.rr-maintenance #' + BAR_ID + '{position:sticky;top:0;}';
+    document.head.appendChild(style);
+  }
+
+  function dismissKey(message) {
+    return 'rr_banner_dismiss_' + String(message || '').slice(0, 80);
+  }
+
+  function render(data) {
+    if (!data || !data.enabled || !data.message) return;
+    try {
+      if (!data.maintenanceMode && sessionStorage.getItem(dismissKey(data.message)) === '1') return;
+    } catch (_) {}
+
+    ensureStyle();
+    var existing = document.getElementById(BAR_ID);
+    if (existing) existing.remove();
+
+    var level = data.level === 'urgent' || data.level === 'warn' ? data.level : 'info';
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.setAttribute('data-level', level);
+    bar.setAttribute('role', 'status');
+
+    var html = '<span>' + esc(data.message) + '</span>';
+    if (data.linkUrl) {
+      html += ' <a href="' + esc(data.linkUrl) + '">' + esc(data.linkLabel || 'Learn more') + '</a>';
+    }
+    if (!data.maintenanceMode) {
+      html += '<button type="button" class="rr-banner-close" aria-label="Dismiss">×</button>';
+    }
+    bar.innerHTML = html;
+
+    var closeBtn = bar.querySelector('.rr-banner-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        try { sessionStorage.setItem(dismissKey(data.message), '1'); } catch (_) {}
+        bar.remove();
+      });
+    }
+
+    document.body.insertBefore(bar, document.body.firstChild);
+    if (data.maintenanceMode) {
+      document.body.classList.add('rr-maintenance');
+    }
+  }
+
+  function tryLoad(attempt) {
+    attempt = attempt || 0;
+    try {
+      var path = (window.location.pathname || '').toLowerCase();
+      if (path.indexOf('admin-console') !== -1 || path.indexOf('setup-admin') !== -1) return;
+      var db = window._rrFirestore || (window.firebase && window.firebase.firestore && window.firebase.firestore());
+      if (!db) throw new Error('no db');
+      db.doc('config/site_banner').get().then(function (snap) {
+        if (snap && snap.exists) render(snap.data() || {});
+      }).catch(function () {});
+    } catch (_) {
+      if (attempt < 40) setTimeout(function () { tryLoad(attempt + 1); }, 250);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { tryLoad(0); });
+  } else {
+    tryLoad(0);
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -917,6 +917,7 @@
       <meta name="twitter:image" content="/assets/img/og-default.jpg" />
       <script src="assets/js/page-meta.js" defer></script>
       <script src="assets/js/site-search.js" defer></script>
+      <script src="assets/js/site-banner.js" defer></script>
   </head>
   <body>
     <!-- Animated Background -->

--- a/ios/RedsRacing/www/admin-console.html
+++ b/ios/RedsRacing/www/admin-console.html
@@ -1232,7 +1232,7 @@
                     Command <span class="text-transparent bg-clip-text bg-gradient-to-r from-cyan-300 via-amber-300 to-rose-400">Center</span>
                   </h1>
                   <p class="text-slate-400 text-sm md:text-base leading-relaxed max-w-xl">
-                    Approvals, race content, analytics, and ops—one cockpit built for race-night speed.
+                    Approvals, race content, site banner, analytics, and ops—one cockpit built for race-night speed.
                   </p>
                   <div class="mt-4 flex flex-wrap items-center gap-2">
                     <span class="admin-hero-chip"><i class="fas fa-circle text-[0.45rem] opacity-80" aria-hidden="true"></i> Live console</span>
@@ -1316,7 +1316,47 @@
               </div>
             </div>
             
-            <!-- Next Race & Notes Row -->
+            <!-- Quick Actions -->
+            <div class="admin-card rounded-xl p-6">
+              <div class="flex items-center justify-between mb-4">
+                <h2 class="text-xl font-bold text-white">
+                  <i class="fas fa-bolt text-amber-400 mr-2"></i>
+                  Quick Actions
+                </h2>
+                <span class="text-xs text-slate-500">Jump to the jobs you do most</span>
+              </div>
+              <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3" id="overview-quick-actions">
+                <a href="#inbox" class="bg-slate-800/60 border border-slate-700/50 hover:border-cyan-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-inbox text-cyan-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Inbox</div>
+                </a>
+                <a href="#media" class="bg-slate-800/60 border border-slate-700/50 hover:border-purple-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-images text-purple-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Gallery</div>
+                </a>
+                <a href="#race" class="bg-slate-800/60 border border-slate-700/50 hover:border-yellow-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-flag-checkered text-yellow-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Results</div>
+                </a>
+                <a href="push-notifications.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-orange-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-bell text-orange-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Notify</div>
+                </a>
+                <a href="#schedule-mgmt" class="bg-slate-800/60 border border-slate-700/50 hover:border-green-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-calendar-alt text-green-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Schedule</div>
+                </a>
+                <a href="live-race-admin.html" class="bg-slate-800/60 border border-slate-700/50 hover:border-red-500/40 rounded-lg p-3 text-center transition group">
+                  <i class="fas fa-broadcast-tower text-red-400 text-lg mb-1 group-hover:scale-110 transition"></i>
+                  <div class="text-white text-xs font-semibold">Go Live</div>
+                </a>
+              </div>
+            </div>
+
+            <!-- Overview tools mount (site banner, staff notes, attention digest) -->
+            <div id="overview-tools" class="grid grid-cols-1 lg:grid-cols-2 gap-6"></div>
+
+                        <!-- Next Race & Notes Row -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
               <!-- Next Race Countdown -->
               <div class="admin-card rounded-xl p-6">
@@ -2440,187 +2480,6 @@
                 <div id="backup-operation-result" class="mt-3 text-sm text-slate-300"></div>
               </div>
 
-              <!-- Mobile App Management -->
-              <div class="admin-card rounded-xl p-6">
-                <h3 class="text-xl font-bold text-white mb-4">
-                  <i class="fas fa-mobile-alt text-cyan-400 mr-2"></i>
-                  Mobile App Management
-                </h3>
-                <p class="text-slate-400 text-sm mb-4">Monitor your Android and iOS apps</p>
-                
-                <!-- App Stats -->
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                  <!-- Android -->
-                  <div class="bg-gradient-to-br from-green-900/30 to-slate-800/30 border border-green-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-android text-green-400 mr-2 text-xl"></i>Android App
-                      </h4>
-                      <span id="android-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="android-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-green-400 font-medium" id="android-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="android-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="android-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- iOS -->
-                  <div class="bg-gradient-to-br from-blue-900/30 to-slate-800/30 border border-blue-700/50 rounded-lg p-4">
-                    <div class="flex items-center justify-between mb-3">
-                      <h4 class="text-white font-semibold flex items-center">
-                        <i class="fab fa-apple text-blue-400 mr-2 text-xl"></i>iOS App
-                      </h4>
-                      <span id="ios-status-badge" class="px-2 py-1 bg-slate-600 text-white text-xs rounded">—</span>
-                    </div>
-                    <div class="space-y-2">
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Version:</span>
-                        <span class="text-white font-medium" id="ios-version">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Devices seen (7d / total):</span>
-                        <span class="text-blue-400 font-medium" id="ios-users">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">WebView JS errors (7d):</span>
-                        <span class="text-yellow-400 font-medium" id="ios-crashes">--</span>
-                      </div>
-                      <div class="flex justify-between text-sm">
-                        <span class="text-slate-400">Store rating:</span>
-                        <span class="text-white font-medium" id="ios-rating">Not tracked</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
-                <!-- App Version Management -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">App Version Management</h4>
-                  
-                  <!-- Version Distribution Stats -->
-                  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">Android Version Distribution</h5>
-                      <div id="android-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                    <div class="bg-slate-900/50 border border-slate-700/50 rounded-lg p-3">
-                      <h5 class="text-white font-medium text-sm mb-2">iOS Version Distribution</h5>
-                      <div id="ios-version-distribution" class="text-xs text-slate-300 space-y-1">
-                        <div class="text-slate-500">Loading...</div>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- Android Version Config -->
-                  <div class="bg-slate-900/50 border border-green-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-android text-green-400 mr-2"></i>Android Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="android-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="android-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="android-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <!-- iOS Version Config -->
-                  <div class="bg-slate-900/50 border border-blue-700/30 rounded-lg p-3 mb-3">
-                    <h5 class="text-white font-medium text-sm mb-2 flex items-center">
-                      <i class="fab fa-apple text-blue-400 mr-2"></i>iOS Version Config
-                    </h5>
-                    <div class="grid grid-cols-2 gap-3">
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Latest Version Code</label>
-                        <input type="number" id="ios-latest-version" class="modern-input w-full p-2 text-white text-sm" placeholder="91" />
-                      </div>
-                      <div>
-                        <label class="block text-xs text-slate-400 mb-1">Minimum Required</label>
-                        <input type="number" id="ios-min-version" class="modern-input w-full p-2 text-white text-sm" placeholder="85" />
-                      </div>
-                    </div>
-                    <div class="mt-2">
-                      <label class="block text-xs text-slate-400 mb-1">Update Message (Optional)</label>
-                      <input type="text" id="ios-update-message" class="modern-input w-full p-2 text-white text-sm" placeholder="New features and bug fixes!" />
-                    </div>
-                  </div>
-                  
-                  <div class="flex justify-end space-x-2">
-                    <button id="load-version-config-btn" class="modern-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-sync mr-2"></i>Load Current
-                    </button>
-                    <button id="save-version-config-btn" class="success-btn text-white px-3 py-2 rounded text-sm">
-                      <i class="fas fa-save mr-2"></i>Save Config
-                    </button>
-                  </div>
-                </div>
-                
-                <!-- Push Notifications -->
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4 mb-4">
-                  <h4 class="text-white font-semibold mb-3">Send Push Notification</h4>
-                  <div class="space-y-3">
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Platform</label>
-                      <select id="push-platform" class="modern-input w-full p-2 text-white">
-                        <option value="both">Both (Android + iOS)</option>
-                        <option value="android">Android Only</option>
-                        <option value="ios">iOS Only</option>
-                      </select>
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Title</label>
-                      <input type="text" id="push-title" class="modern-input w-full p-2 text-white" placeholder="Race Alert!" />
-                    </div>
-                    <div>
-                      <label class="block text-sm text-slate-300 mb-1">Message</label>
-                      <textarea id="push-message" rows="2" class="modern-input w-full p-2 text-white resize-none" placeholder="Next race starts in 1 hour!"></textarea>
-                    </div>
-                  </div>
-                  <div class="mt-4 flex justify-end">
-                    <button id="send-push-notification-btn" class="success-btn text-white px-4 py-2 rounded text-sm">
-                      <i class="fas fa-bell mr-2"></i>Send Notification
-                    </button>
-                  </div>
-                </div>
-                
-                <div class="flex flex-wrap gap-2">
-                  <button id="refresh-app-stats-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-sync mr-2"></i>Refresh Stats
-                  </button>
-                  <button id="view-crash-reports-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-bug mr-2"></i>View Crash Reports
-                  </button>
-                  <button id="app-analytics-btn" class="modern-btn text-white px-4 py-2 rounded text-sm">
-                    <i class="fas fa-chart-bar mr-2"></i>App Analytics
-                  </button>
-                </div>
-                <div id="app-operation-result" class="mt-3 text-sm text-slate-300"></div>
-              </div>
-
               <!-- Revenue & Monetization -->
               <div class="admin-card rounded-xl p-6">
                 <h3 class="text-xl font-bold text-white mb-4">
@@ -3217,7 +3076,7 @@
                     <i class="fas fa-heartbeat text-red-400 mr-3"></i>
                     Site Health Dashboard
                   </h2>
-                  <p class="text-slate-400 text-sm mt-1">Monitor app versions, system status, and error rates</p>
+                  <p class="text-slate-400 text-sm mt-1">Monitor site status, system health, and error rates</p>
                 </div>
                 <div class="flex items-center space-x-3">
                   <span class="text-slate-500 text-xs" id="health-last-check"></span>
@@ -3227,25 +3086,9 @@
                 </div>
               </div>
 
-              <!-- App Versions -->
-              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-mobile-alt text-blue-400 mr-2"></i>App Versions</h3>
-              <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-android text-green-400 text-xl"></i>
-                    <span class="text-white font-semibold">Android</span>
-                  </div>
-                  <div class="text-2xl font-bold text-green-400" id="health-android-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-android-code">Build --</div>
-                </div>
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
-                  <div class="flex items-center space-x-3 mb-2">
-                    <i class="fab fa-apple text-slate-300 text-xl"></i>
-                    <span class="text-white font-semibold">iOS</span>
-                  </div>
-                  <div class="text-2xl font-bold text-slate-300" id="health-ios-ver">--</div>
-                  <div class="text-xs text-slate-500" id="health-ios-code">Build --</div>
-                </div>
+              <!-- Site Version -->
+              <h3 class="text-lg font-bold text-white mb-3"><i class="fas fa-globe text-blue-400 mr-2"></i>Site Version</h3>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
                 <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
                   <div class="flex items-center space-x-3 mb-2">
                     <i class="fas fa-globe text-blue-400 text-xl"></i>
@@ -3253,6 +3096,14 @@
                   </div>
                   <div class="text-2xl font-bold text-blue-400" id="health-web-ver">--</div>
                   <div class="text-xs text-slate-500" id="health-web-url">redsracing.org</div>
+                </div>
+                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-4">
+                  <div class="flex items-center space-x-3 mb-2">
+                    <i class="fas fa-bullhorn text-amber-400 text-xl"></i>
+                    <span class="text-white font-semibold">Public Banner</span>
+                  </div>
+                  <div class="text-lg font-semibold text-amber-300" id="health-banner-status">--</div>
+                  <div class="text-xs text-slate-500" id="health-banner-preview">Managed from Overview tools</div>
                 </div>
               </div>
 
@@ -5759,26 +5610,23 @@
             // Reset stat values to show loading
             ['health-errors-24h','health-errors-7d','health-subscribers'].forEach(id => el(id, '...'));
             el('health-top-error-page', '...');
-            // ---- App versions from app_config (replaces hardcoded values) ----
-            try {
-              const androidCfg = await getDoc(doc(db, 'app_config', 'android_version'));
-              if (androidCfg.exists()) {
-                const d = androidCfg.data();
-                el('health-android-ver', d.version_name || d.latest_version || '?');
-                el('health-android-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-android-ver', 'No config'); el('health-android-code', '--'); }
-              const iosCfg = await getDoc(doc(db, 'app_config', 'ios_version'));
-              if (iosCfg.exists()) {
-                const d = iosCfg.data();
-                el('health-ios-ver', d.version_name || d.latest_version || '?');
-                el('health-ios-code', 'Build ' + (d.latest_version || d.version_code || '?'));
-              } else { el('health-ios-ver', 'No config'); el('health-ios-code', '--'); }
-            } catch(e) {
-              console.warn('Failed to read app_config versions:', e);
-              el('health-android-ver', '?'); el('health-android-code', '?');
-              el('health-ios-ver', '?'); el('health-ios-code', '?');
-            }
+            // ---- Site version + public banner status ----
             el('health-web-ver', document.querySelector('meta[name="app-version"]')?.content || 'live');
+            try {
+              const bannerCfg = await getDoc(doc(db, 'config', 'site_banner'));
+              if (bannerCfg.exists()) {
+                const d = bannerCfg.data() || {};
+                const on = !!d.enabled;
+                el('health-banner-status', on ? (d.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off');
+                el('health-banner-preview', (d.message || '').toString().slice(0, 80) || 'No message set');
+              } else {
+                el('health-banner-status', 'Off');
+                el('health-banner-preview', 'No banner configured');
+              }
+            } catch (e) {
+              el('health-banner-status', '?');
+              el('health-banner-preview', 'Could not load');
+            }
             // Firebase status
             const setStatus = (prefix, ok, msg) => {
               const dot = document.getElementById(prefix + '-dot');
@@ -7127,18 +6975,6 @@
         
         // ===== NEW ADMIN TOOLS FUNCTIONS =====
 
-        function __isAndroidAppUserAgent(ua) {
-          const s = String(ua || '').toLowerCase();
-          if (!s) return false;
-          return s.includes('android') && (s.includes('; wv') || s.includes('redsracingapp'));
-        }
-
-        function __isIosAppUserAgent(ua) {
-          const s = String(ua || '');
-          if (!s) return false;
-          return /iphone|ipad|ipod/i.test(s) && (s.includes('Mobile/') || s.includes('RedsRacingApp'));
-        }
-
         async function loadEmailMarketingStats() {
           const { getFirestore, collection, getDocs, query, orderBy, limit, getCountFromServer } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
           const app = await ensureDefaultApp();
@@ -7198,16 +7034,6 @@
             document.getElementById('backup-size').textContent = '0 KB';
             document.getElementById('backup-count').textContent = '0';
             
-            // Mobile App stats (versions come from app_config via loadVersionConfig)
-            document.getElementById('android-version').textContent = '--';
-            document.getElementById('ios-version').textContent = '--';
-            document.getElementById('android-users').textContent = '--';
-            document.getElementById('ios-users').textContent = '--';
-            document.getElementById('android-crashes').textContent = '--';
-            document.getElementById('ios-crashes').textContent = '--';
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-            
             // Revenue stats
             document.getElementById('revenue-today').textContent = '$--';
             document.getElementById('revenue-month').textContent = '$--';
@@ -7224,12 +7050,6 @@
             
             // Load initial activity stats
             try { await refreshUserActivity(); } catch(e) { console.warn('Activity refresh failed:', e); }
-            // Load initial app stats
-            try { await refreshAppStats(); } catch(e) { console.warn('App stats refresh failed:', e); }
-            // Load configured app versions into cards + form
-            try { await loadVersionConfig(); } catch(e) { console.warn('Version config load failed:', e); }
-            // Load version distribution
-            try { await loadVersionDistribution(); } catch(e) { console.warn('Version distribution load failed:', e); }
             // Load initial revenue stats
             try { await refreshRevenueStats(); } catch(e) { console.warn('Revenue stats refresh failed:', e); }
           } catch(e) {
@@ -7348,25 +7168,6 @@
           
           const exportAllDataBtn = document.getElementById('export-all-data-btn');
           if (exportAllDataBtn) exportAllDataBtn.addEventListener('click', exportAllData);
-          
-          // Mobile App Management
-          const loadVersionConfigBtn = document.getElementById('load-version-config-btn');
-          if (loadVersionConfigBtn) loadVersionConfigBtn.addEventListener('click', loadVersionConfig);
-          
-          const saveVersionConfigBtn = document.getElementById('save-version-config-btn');
-          if (saveVersionConfigBtn) saveVersionConfigBtn.addEventListener('click', saveVersionConfig);
-          
-          const refreshAppStatsBtn = document.getElementById('refresh-app-stats-btn');
-          if (refreshAppStatsBtn) refreshAppStatsBtn.addEventListener('click', refreshAppStats);
-          
-          const sendPushNotificationBtn = document.getElementById('send-push-notification-btn');
-          if (sendPushNotificationBtn) sendPushNotificationBtn.addEventListener('click', sendPushNotification);
-          
-          const viewCrashReportsBtn = document.getElementById('view-crash-reports-btn');
-          if (viewCrashReportsBtn) viewCrashReportsBtn.addEventListener('click', viewCrashReports);
-          
-          const appAnalyticsBtn = document.getElementById('app-analytics-btn');
-          if (appAnalyticsBtn) appAnalyticsBtn.addEventListener('click', showAppAnalytics);
           
           // Revenue & Monetization
           const refreshRevenueBtn = document.getElementById('refresh-revenue-btn');
@@ -8816,710 +8617,6 @@
           const simple = s.match(/\d+\.\d+/);
           if (simple && simple[0]) return simple[0];
           return '';
-        }
-        
-        async function refreshAppStats() {
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const msDay = 86400000;
-            const cutoff7d = Timestamp.fromDate(new Date(Date.now() - 7 * msDay));
-
-            const toMillis = (ts) => {
-              try {
-                if (!ts) return null;
-                if (ts.toMillis) return ts.toMillis();
-                const d = ts.toDate ? ts.toDate() : new Date(ts);
-                const n = d.getTime();
-                return Number.isFinite(n) ? n : null;
-              } catch (_) {
-                return null;
-              }
-            };
-
-            // --- Real install / activity signals from app_usage (FCM token doc IDs) ---
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            let androidTotal = 0;
-            let iosTotal = 0;
-            let androidSeen7d = 0;
-            let iosSeen7d = 0;
-            let androidLatestSeen = null;
-            let iosLatestSeen = null;
-            let androidLatestName = '';
-            let iosLatestName = '';
-
-            usageSnap.forEach((docSnap) => {
-              const d = docSnap.data() || {};
-              const platform = String(d.platform || '').toLowerCase();
-              const lastMs = toMillis(d.last_seen) ?? toMillis(d.lastSeen);
-              const seenRecently = lastMs !== null && lastMs >= (Date.now() - 7 * msDay);
-
-              const parsed =
-                extractVersionCode(d.app_version_code) ??
-                extractVersionCode(d.versionCode) ??
-                extractVersionCode(d.build) ??
-                extractVersionCode(d.app_version) ??
-                extractVersionCode(d.version) ??
-                extractVersionCode(d.appVersion);
-              const parsedName =
-                extractVersionName(d.app_version_name) ||
-                extractVersionName(d.versionName) ||
-                extractVersionName(d.app_version) ||
-                extractVersionName(d.version) ||
-                extractVersionName(d.appVersion);
-
-              if (platform === 'android') {
-                androidTotal += 1;
-                if (seenRecently) androidSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  androidLatestSeen = androidLatestSeen === null ? parsed : Math.max(androidLatestSeen, parsed);
-                  if (parsedName) androidLatestName = parsedName;
-                } else if (parsedName) {
-                  androidLatestName = parsedName;
-                }
-              } else if (platform === 'ios') {
-                iosTotal += 1;
-                if (seenRecently) iosSeen7d += 1;
-                if (Number.isFinite(parsed)) {
-                  iosLatestSeen = iosLatestSeen === null ? parsed : Math.max(iosLatestSeen, parsed);
-                  if (parsedName) iosLatestName = parsedName;
-                } else if (parsedName) {
-                  iosLatestName = parsedName;
-                }
-              }
-            });
-
-            const androidUsersEl = document.getElementById('android-users');
-            const iosUsersEl = document.getElementById('ios-users');
-            if (androidUsersEl) androidUsersEl.textContent = androidTotal ? `${androidSeen7d} / ${androidTotal}` : '--';
-            if (iosUsersEl) iosUsersEl.textContent = iosTotal ? `${iosSeen7d} / ${iosTotal}` : '--';
-
-            // --- WebView JS error rate (7d): client_logs errors vs page_views in app WebViews ---
-            const isTrackedError = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            const classifyPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              if (__isAndroidAppUserAgent(ua)) return 'android';
-              if (__isIosAppUserAgent(ua)) return 'ios';
-              if (String(url).includes('appassets.androidplatform.net')) return 'android';
-              return null;
-            };
-
-            let logs = [];
-            try {
-              const logSnap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff7d), orderBy('serverTimestamp', 'desc'), limit(1500)));
-              logs = logSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const logSnap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(1500)));
-                logs = logSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                logs = [];
-              }
-            }
-
-            let pv = [];
-            try {
-              const pvSnap = await getDocs(query(collection(db, 'page_views'), where('timestamp', '>=', cutoff7d), orderBy('timestamp', 'desc'), limit(4000)));
-              pv = pvSnap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              try {
-                const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(4000)));
-                pv = pvSnap.docs.map((d) => d.data() || {});
-              } catch (_) {
-                pv = [];
-              }
-            }
-
-            const cutoffMs = Date.now() - 7 * msDay;
-            const logInWindow = (v) => {
-              const ms = toMillis(v.serverTimestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-            const pvInWindow = (v) => {
-              const ms = toMillis(v.timestamp) ?? toMillis(v.createdAt);
-              return ms !== null && ms >= cutoffMs;
-            };
-
-            const logsW = logs.filter(logInWindow);
-            const pvW = pv.filter(pvInWindow);
-
-            const errAndroid = logsW.filter((v) => isTrackedError(v) && __isAndroidAppUserAgent(v.userAgent)).length;
-            const errIos = logsW.filter((v) => isTrackedError(v) && __isIosAppUserAgent(v.userAgent)).length;
-            const pvAndroid = pvW.filter((v) => classifyPv(v) === 'android').length;
-            const pvIos = pvW.filter((v) => classifyPv(v) === 'ios').length;
-
-            const fmtRate = (errs, views) => {
-              if (!views) return 'N/A';
-              return `${((errs / views) * 100).toFixed(2)}%`;
-            };
-
-            const androidCrashEl = document.getElementById('android-crashes');
-            const iosCrashEl = document.getElementById('ios-crashes');
-            if (androidCrashEl) androidCrashEl.textContent = fmtRate(errAndroid, pvAndroid);
-            if (iosCrashEl) iosCrashEl.textContent = fmtRate(errIos, pvIos);
-
-            document.getElementById('android-rating').textContent = 'Not tracked';
-            document.getElementById('ios-rating').textContent = 'Not tracked';
-
-            // Use config minimums if available (for display only)
-            const androidMin = parseInt(document.getElementById('android-min-version')?.value, 10);
-            const iosMin = parseInt(document.getElementById('ios-min-version')?.value, 10);
-
-            if (androidLatestSeen !== null || androidLatestName) {
-              const codePart = Number.isFinite(androidLatestSeen) ? androidLatestSeen : '';
-              const namePart = androidLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(androidMin) && codePart !== '') {
-                label = `${label} · min ${androidMin}`;
-              }
-              document.getElementById('android-version').textContent = label;
-            }
-            if (iosLatestSeen !== null || iosLatestName) {
-              const codePart = Number.isFinite(iosLatestSeen) ? iosLatestSeen : '';
-              const namePart = iosLatestName || '';
-              let label = '';
-              if (namePart && codePart !== '') label = `${namePart} (${codePart})`;
-              else if (namePart) label = namePart;
-              else if (codePart !== '') label = `build ${codePart}`;
-              if (Number.isFinite(iosMin) && codePart !== '') {
-                label = `${label} · min ${iosMin}`;
-              }
-              document.getElementById('ios-version').textContent = label;
-            }
-
-            // Real status badges based on whether we've seen recent traffic
-            // from the platform (last 7 days of page_views with the matching
-            // user-agent). Replaces the always-on hardcoded "Live" labels.
-            const androidBadge = document.getElementById('android-status-badge');
-            const iosBadge = document.getElementById('ios-status-badge');
-            if (androidBadge) {
-              const seen = parseInt(document.getElementById('android-users')?.textContent || '0', 10) > 0;
-              androidBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              androidBadge.className = `px-2 py-1 ${seen ? 'bg-green-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-            if (iosBadge) {
-              const seen = parseInt(document.getElementById('ios-users')?.textContent || '0', 10) > 0;
-              iosBadge.textContent = seen ? 'Active' : 'No recent traffic';
-              iosBadge.className = `px-2 py-1 ${seen ? 'bg-blue-600' : 'bg-slate-600'} text-white text-xs rounded`;
-            }
-
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App stats refreshed from <span class="text-slate-200">app_usage</span>, <span class="text-slate-200">page_views</span>, and <span class="text-slate-200">client_logs</span></div>';
-            showToast('App stats refreshed');
-          } catch(e) {
-            console.error('Failed to refresh app stats:', e);
-            showToast('Failed to refresh app stats', 'error');
-          }
-        }
-        
-        async function sendPushNotification() {
-          try {
-            console.log('[Push Notification] Checking user role...');
-            const role = await getUserRole();
-            console.log('[Push Notification] User role:', role);
-            
-            if (!role) {
-              console.error('[Push Notification] No role found - user may not be authenticated');
-              showToast('Please log in to send push notifications', 'error');
-              return;
-            }
-            
-            if (!isModeratorRole(role)) {
-              console.warn('[Push Notification] User role insufficient:', role);
-              showToast(`You need to be a team-member or admin to send push notifications (current role: ${role})`, 'error');
-              return;
-            }
-            
-            console.log('[Push Notification] Role check passed:', role);
-            
-            const platform = document.getElementById('push-platform').value;
-            const title = document.getElementById('push-title').value;
-            const message = document.getElementById('push-message').value;
-            
-            if (!title || !message) {
-              showToast('Please fill in title and message', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Sending...';
-            
-            const { getFirestore, collection, addDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            // Store notification in Firestore for Cloud Function to send
-            try {
-              const notificationData = {
-                platform,
-                title,
-                message,
-                timestamp: serverTimestamp(),
-                sentBy: auth.currentUser?.uid || null,
-                status: 'pending'
-              };
-              
-              await addDoc(collection(db, 'push_notifications'), notificationData);
-              
-              // Also log to admin logs
-              await addDoc(collection(db, 'admin_logs'), {
-                action: 'push_notification_sent',
-                platform,
-                title,
-                message: message.substring(0, 100),
-                timestamp: serverTimestamp(),
-                uid: auth.currentUser?.uid || null,
-                role: role || 'unknown'
-              });
-            } catch(error) {
-              console.error('Failed to queue push notification:', error);
-              throw error;
-            }
-            
-            // Clear form
-            document.getElementById('push-title').value = '';
-            document.getElementById('push-message').value = '';
-            
-            document.getElementById('app-operation-result').innerHTML = 
-              `<div class="text-green-400"><i class="fas fa-check mr-2"></i>Push notification queued for ${platform}. Users will receive it shortly.</div>`;
-            showToast('Push notification sent!');
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          } catch(e) {
-            console.error('Failed to send push notification:', e);
-            showToast('Failed to send push notification', 'error');
-            const btn = document.getElementById('send-push-notification-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-bell mr-2"></i>Send Notification';
-          }
-        }
-        
-        async function loadVersionConfig() {
-          try {
-            const btn = document.getElementById('load-version-config-btn');
-            if (btn) {
-              btn.disabled = true;
-              btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Loading...';
-            }
-            
-            const { getFirestore, doc, getDoc, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            // Load Android config
-            const androidDoc = await getDoc(doc(db, 'app_config', 'android_version'));
-            if (androidDoc.exists()) {
-              const data = androidDoc.data();
-              document.getElementById('android-latest-version').value = data.latest_version || '';
-              document.getElementById('android-min-version').value = data.minimum_version || '';
-              document.getElementById('android-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('android-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('android-latest-version').value = '';
-              document.getElementById('android-min-version').value = '';
-              const vEl = document.getElementById('android-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load iOS config
-            const iosDoc = await getDoc(doc(db, 'app_config', 'ios_version'));
-            if (iosDoc.exists()) {
-              const data = iosDoc.data();
-              document.getElementById('ios-latest-version').value = data.latest_version || '';
-              document.getElementById('ios-min-version').value = data.minimum_version || '';
-              document.getElementById('ios-update-message').value = data.update_message || '';
-              const latest = data.latest_version;
-              const min = data.minimum_version;
-              const vEl = document.getElementById('ios-version');
-              if (vEl) {
-                if (latest != null && min != null) vEl.textContent = `latest ${latest} (min ${min})`;
-                else if (latest != null) vEl.textContent = `latest ${latest}`;
-                else vEl.textContent = '--';
-              }
-            } else {
-              document.getElementById('ios-latest-version').value = '';
-              document.getElementById('ios-min-version').value = '';
-              const vEl = document.getElementById('ios-version');
-              if (vEl) vEl.textContent = '--';
-            }
-            
-            // Load version distribution from app_usage collection
-            await loadVersionDistribution();
-            
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-            
-            showToast('Version config loaded');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>Version configuration loaded successfully</div>';
-          } catch(e) {
-            console.error('Failed to load version config:', e);
-            showToast('Failed to load version config', 'error');
-            let loadBtn = document.getElementById('load-version-config-btn');
-            if (loadBtn) {
-              loadBtn.disabled = false;
-              loadBtn.innerHTML = '<i class="fas fa-sync mr-2"></i>Load Current';
-            }
-          }
-        }
-        
-        async function saveVersionConfig() {
-          try {
-            const role = await getUserRole();
-            if (role !== 'admin') {
-              showToast('You need to be an admin to manage app versions', 'error');
-              return;
-            }
-            
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Saving...';
-            
-            const { getFirestore, doc, setDoc, serverTimestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const { getAuth } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-auth.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const auth = getAuth();
-            
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || 0;
-            const androidMin = parseInt(document.getElementById('android-min-version').value) || 0;
-            const androidMessage = document.getElementById('android-update-message').value;
-            
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || 0;
-            const iosMin = parseInt(document.getElementById('ios-min-version').value) || 0;
-            const iosMessage = document.getElementById('ios-update-message').value;
-            
-            // Save Android config
-            await setDoc(doc(db, 'app_config', 'android_version'), {
-              latest_version: androidLatest,
-              minimum_version: androidMin,
-              update_message: androidMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            // Save iOS config
-            await setDoc(doc(db, 'app_config', 'ios_version'), {
-              latest_version: iosLatest,
-              minimum_version: iosMin,
-              update_message: iosMessage,
-              updated_at: serverTimestamp(),
-              updated_by: auth.currentUser?.uid || null
-            });
-            
-            showToast('Version config saved successfully');
-            document.getElementById('app-operation-result').innerHTML = 
-              '<div class="text-green-400"><i class="fas fa-check mr-2"></i>App version config updated. Users will be prompted on next app launch.</div>';
-            document.getElementById('android-version').textContent = `v${androidLatest} (min v${androidMin})`;
-            document.getElementById('ios-version').textContent = `v${iosLatest} (min v${iosMin})`;
-            
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          } catch(e) {
-            console.error('Failed to save version config:', e);
-            showToast('Failed to save version config', 'error');
-            const btn = document.getElementById('save-version-config-btn');
-            btn.disabled = false;
-            btn.innerHTML = '<i class="fas fa-save mr-2"></i>Save Config';
-          }
-        }
-        
-        async function loadVersionDistribution() {
-          try {
-            const { getFirestore, collection, getDocs } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            
-            const usageSnap = await getDocs(collection(db, 'app_usage'));
-            const androidVersions = {};
-            const iosVersions = {};
-            const androidLatest = parseInt(document.getElementById('android-latest-version').value) || null;
-            const iosLatest = parseInt(document.getElementById('ios-latest-version').value) || null;
-            
-            usageSnap.forEach(doc => {
-              const data = doc.data();
-              const platform = data.platform;
-              const version = data.app_version;
-              
-              if (platform === 'android' && version) {
-                androidVersions[version] = (androidVersions[version] || 0) + 1;
-              } else if (platform === 'ios' && version) {
-                iosVersions[version] = (iosVersions[version] || 0) + 1;
-              }
-            });
-            
-            // Display Android distribution
-            const androidDiv = document.getElementById('android-version-distribution');
-            if (Object.keys(androidVersions).length === 0) {
-              androidDiv.innerHTML = androidLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-green-400 font-medium">v${androidLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const androidTotal = Object.values(androidVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(androidVersions).sort((a, b) => b[1] - a[1]);
-              androidDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / androidTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-green-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-            
-            // Display iOS distribution
-            const iosDiv = document.getElementById('ios-version-distribution');
-            if (Object.keys(iosVersions).length === 0) {
-              iosDiv.innerHTML = iosLatest
-                ? `<div class="text-slate-400">Latest configured: <span class="text-blue-400 font-medium">v${iosLatest}</span></div>`
-                : '<div class="text-slate-500">No version data available</div>';
-            } else {
-              const iosTotal = Object.values(iosVersions).reduce((a, b) => a + b, 0);
-              const sorted = Object.entries(iosVersions).sort((a, b) => b[1] - a[1]);
-              iosDiv.innerHTML = sorted.map(([version, count]) => {
-                const percent = ((count / iosTotal) * 100).toFixed(1);
-                return `
-                  <div class="flex justify-between items-center">
-                    <span class="text-slate-300">v${version}:</span>
-                    <div class="flex items-center space-x-2">
-                      <div class="w-24 h-2 bg-slate-700 rounded overflow-hidden">
-                        <div class="h-full bg-blue-400" style="width: ${percent}%"></div>
-                      </div>
-                      <span class="text-slate-400 w-16 text-right">${count} (${percent}%)</span>
-                    </div>
-                  </div>
-                `;
-              }).join('');
-            }
-          } catch(e) {
-            console.error('Failed to load version distribution:', e);
-            document.getElementById('android-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-            document.getElementById('ios-version-distribution').innerHTML = 
-              '<div class="text-red-400 text-xs">Failed to load</div>';
-          }
-        }
-        
-        async function viewCrashReports() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading error telemetry...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, where, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-            const cutoff = Timestamp.fromDate(new Date(Date.now() - 7 * 86400000));
-
-            const isErr = (v) => {
-              if (!v || typeof v !== 'object') return false;
-              if (v.level === 'error') return true;
-              if (typeof v.errorType === 'string' && v.errorType) return true;
-              if (v.stack && v.stack !== 'No stack trace available') return true;
-              return false;
-            };
-
-            let rows = [];
-            try {
-              const snap = await getDocs(query(collection(db, 'client_logs'), where('serverTimestamp', '>=', cutoff), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            } catch (_) {
-              const snap = await getDocs(query(collection(db, 'client_logs'), orderBy('serverTimestamp', 'desc'), limit(800)));
-              rows = snap.docs.map((d) => d.data() || {});
-            }
-
-            const inWin = (v) => {
-              try {
-                const ts = v.serverTimestamp?.toMillis ? v.serverTimestamp.toMillis() : null;
-                return ts !== null && ts >= (Date.now() - 7 * 86400000);
-              } catch (_) {
-                return true;
-              }
-            };
-
-            const filtered = rows.filter((v) => isErr(v) && inWin(v));
-            let android = 0;
-            let ios = 0;
-            let web = 0;
-            const samples = [];
-            filtered.forEach((v) => {
-              const ua = v.userAgent || '';
-              if (__isAndroidAppUserAgent(ua)) android += 1;
-              else if (__isIosAppUserAgent(ua)) ios += 1;
-              else web += 1;
-              const msg = (v.message || v.error || '').toString().slice(0, 160);
-              if (msg && samples.length < 6) samples.push(msg);
-            });
-
-            const sampleHtml = samples.length
-              ? `<div class="text-slate-400 text-xs mt-2"><div class="text-slate-300 font-semibold mb-1">Recent samples</div><ul class="list-disc pl-5 space-y-1">${samples.map((m) => `<li>${m}</li>`).join('')}</ul></div>`
-              : '';
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">Client errors (7 days)</div>
-                  <div class="text-slate-500 text-[11px]">This is JavaScript / WebView telemetry from <span class="text-slate-300">client_logs</span>, not native Crashlytics.</div>
-                  <div class="text-slate-300 text-xs">Android WebView: <span class="text-yellow-300 font-medium">${android}</span></div>
-                  <div class="text-slate-300 text-xs">iOS WebView: <span class="text-yellow-300 font-medium">${ios}</span></div>
-                  <div class="text-slate-300 text-xs">Other / web: <span class="text-yellow-300 font-medium">${web}</span></div>
-                  ${sampleHtml}
-                </div>`;
-            }
-            showToast('Error telemetry loaded');
-          } catch (e) {
-            console.error('Crash report load failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load error telemetry</div>';
-            showToast('Failed to load crash reports', 'error');
-          }
-        }
-        
-        async function showAppAnalytics() {
-          const out = document.getElementById('app-operation-result');
-          if (out) {
-            out.innerHTML = '<div class="text-blue-400"><i class="fas fa-spinner fa-spin mr-2"></i>Loading in-app analytics...</div>';
-          }
-          try {
-            const { getFirestore, collection, getDocs, query, orderBy, limit, Timestamp } = await import('https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore.js');
-            const app = await ensureDefaultApp();
-            const db = getFirestore(app);
-
-            const pvSnap = await getDocs(query(collection(db, 'page_views'), orderBy('timestamp', 'desc'), limit(5000)));
-            const pageViews = pvSnap.docs.map((d) => d.data() || {});
-
-            const dayStart = (d) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-            const today = dayStart(new Date());
-            const yday = today - 86400000;
-
-            const isAppPv = (v) => {
-              const ua = v.userAgent || '';
-              const url = v.url || '';
-              return __isAndroidAppUserAgent(ua) || __isIosAppUserAgent(ua) || String(url).includes('appassets.androidplatform.net');
-            };
-
-            const appPvs = pageViews.filter(isAppPv);
-
-            const visitorsToday = new Set();
-            const visitorsYesterday = new Set();
-            const sessionsToday = new Set();
-
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts) return;
-              const day = dayStart(ts);
-              const vid = v.visitorId || v.sessionId;
-              if (!vid) return;
-              if (day === today) {
-                visitorsToday.add(vid);
-                if (v.sessionId) sessionsToday.add(v.sessionId);
-              }
-              if (day === yday) visitorsYesterday.add(vid);
-            });
-
-            const dau = visitorsToday.size;
-            const yau = visitorsYesterday.size;
-            const dauNote = yau > 0 ? `${dau} today · ${yau} yesterday (unique visitor ids)` : `${dau} today (unique visitor ids)`;
-
-            const aeSnap = await getDocs(query(collection(db, 'analytics_events'), orderBy('timestamp', 'desc'), limit(5000)));
-            const events = aeSnap.docs.map((d) => d.data() || {});
-
-            const isAppEvent = (e) => __isAndroidAppUserAgent(e.userAgent || '') || __isIosAppUserAgent(e.userAgent || '');
-            const appEvents = events.filter(isAppEvent);
-
-            const sevenAgo = Date.now() - 7 * 86400000;
-            const recentAppEvents = appEvents.filter((e) => {
-              try {
-                const ts = e.timestamp?.toMillis ? e.timestamp.toMillis() : (e.timestamp?.toDate ? e.timestamp.toDate().getTime() : null);
-                return ts !== null && ts >= sevenAgo;
-              } catch (_) {
-                return true;
-              }
-            });
-
-            const engagements = recentAppEvents.filter((e) => e.event === 'page_engagement' && e.params && Number.isFinite(Number(e.params.duration_seconds)));
-            const avgEng = engagements.length
-              ? Math.round(engagements.reduce((s, e) => s + Number(e.params.duration_seconds || 0), 0) / engagements.length)
-              : null;
-
-            const featureCounts = {};
-            recentAppEvents.forEach((e) => {
-              const name = e.event || 'unknown';
-              if (name === 'page_engagement') return;
-              featureCounts[name] = (featureCounts[name] || 0) + 1;
-            });
-            const topFeature = Object.entries(featureCounts).sort((a, b) => b[1] - a[1])[0];
-
-            const byVisitorDays = {};
-            appPvs.forEach((v) => {
-              let ts = null;
-              try {
-                ts = v.timestamp?.toDate ? v.timestamp.toDate() : (v.timestamp ? new Date(v.timestamp) : null);
-              } catch (_) {
-                ts = null;
-              }
-              if (!ts || !v.visitorId) return;
-              if (ts.getTime() < sevenAgo) return;
-              const dayKey = ts.toISOString().split('T')[0];
-              if (!byVisitorDays[v.visitorId]) byVisitorDays[v.visitorId] = new Set();
-              byVisitorDays[v.visitorId].add(dayKey);
-            });
-            const multiDayVisitors = Object.values(byVisitorDays).filter((s) => s.size >= 2).length;
-
-            if (out) {
-              out.innerHTML = `
-                <div class="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3 space-y-2">
-                  <div class="text-white font-semibold text-sm">In-app usage (Firestore telemetry)</div>
-                  <div class="text-slate-500 text-[11px]">Based on <span class="text-slate-300">page_views</span> + <span class="text-slate-300">analytics_events</span> from WebViews. This is not a substitute for Firebase Analytics retention reporting.</div>
-                  <div class="text-slate-300 text-sm">• Daily active visitors (app WebView): <span class="text-white font-medium">${dauNote}</span></div>
-                  <div class="text-slate-300 text-sm">• Avg engagement sample (7d): <span class="text-white font-medium">${avgEng == null ? 'N/A' : (avgEng + 's')}</span></div>
-                  <div class="text-slate-300 text-sm">• Multi-day visitors (7d, same visitor id): <span class="text-white font-medium">${multiDayVisitors}</span></div>
-                  <div class="text-slate-300 text-sm">• Top event (7d): <span class="text-white font-medium">${topFeature ? `${topFeature[0]} (${topFeature[1]})` : 'N/A'}</span></div>
-                </div>`;
-            }
-            showToast('Analytics loaded');
-          } catch (e) {
-            console.error('App analytics failed:', e);
-            if (out) out.innerHTML = '<div class="text-red-400 text-sm">Failed to load analytics</div>';
-            showToast('Failed to load analytics', 'error');
-          }
         }
         
         // ===== REVENUE & MONETIZATION =====
@@ -11061,7 +10158,8 @@
           'assets/js/feature-flags.js',
           'assets/js/admin-modules/bulk-photo-import.js',
           'assets/js/admin-modules/fan-passport.js',
-          'assets/js/admin-modules/quick-composer.js'
+          'assets/js/admin-modules/quick-composer.js',
+          'assets/js/admin-modules/console-enhancements.js'
         ];
         window.RR.adminAuthReady.then(function () {
           function loadNext(i) {

--- a/ios/RedsRacing/www/assets/js/admin-modules/console-enhancements.js
+++ b/ios/RedsRacing/www/assets/js/admin-modules/console-enhancements.js
@@ -1,0 +1,255 @@
+/**
+ * Admin console enhancements — Overview tools:
+ *  - Attention digest (pending work counts)
+ *  - Public site banner / maintenance mode
+ *  - Staff notes pad
+ */
+(function () {
+  'use strict';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function db() {
+    return window.firebase && window.firebase.firestore && window.firebase.firestore();
+  }
+
+  function toast(msg, type) {
+    if (typeof window.showToast === 'function') window.showToast(msg, type);
+  }
+
+  function init() {
+    var mount = document.getElementById('overview-tools');
+    if (!mount || mount.dataset.rrEnhanced === '1') return;
+    mount.dataset.rrEnhanced = '1';
+
+    mount.innerHTML =
+      '<div class="admin-card rounded-xl p-6">' +
+        '<div class="flex items-center justify-between mb-4">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-clipboard-list text-cyan-400 mr-2"></i>Needs Attention</h2>' +
+          '<button type="button" id="ce-attn-refresh" class="modern-btn text-white px-3 py-1.5 rounded text-xs"><i class="fas fa-sync mr-1"></i>Refresh</button>' +
+        '</div>' +
+        '<div id="ce-attn-list" class="space-y-2 text-sm"><div class="text-slate-500">Loading…</div></div>' +
+        '<a href="#inbox" class="inline-block mt-4 text-xs text-cyan-400 hover:text-cyan-300">Open full inbox →</a>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6">' +
+        '<h2 class="text-xl font-bold text-white mb-1"><i class="fas fa-bullhorn text-amber-400 mr-2"></i>Site Banner</h2>' +
+        '<p class="text-slate-400 text-xs mb-4">Show a public notice across the site. Use maintenance mode for race-night downtime.</p>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-enabled" class="rounded" /> Enable banner' +
+        '</label>' +
+        '<label class="flex items-center gap-2 text-sm text-slate-300 mb-3 cursor-pointer">' +
+          '<input type="checkbox" id="ce-banner-maintenance" class="rounded" /> Maintenance mode (non-dismissible)' +
+        '</label>' +
+        '<label class="block text-xs text-slate-400 mb-1">Level</label>' +
+        '<select id="ce-banner-level" class="modern-input w-full p-2 text-white text-sm mb-3">' +
+          '<option value="info">Info</option>' +
+          '<option value="warn">Warning</option>' +
+          '<option value="urgent">Urgent</option>' +
+        '</select>' +
+        '<label class="block text-xs text-slate-400 mb-1">Message</label>' +
+        '<textarea id="ce-banner-message" rows="2" class="modern-input w-full p-2 text-white text-sm mb-3 resize-none" placeholder="Track day cancelled — new date TBA"></textarea>' +
+        '<div class="grid grid-cols-1 md:grid-cols-2 gap-2 mb-3">' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Optional link URL</label>' +
+          '<input id="ce-banner-link" type="url" class="modern-input w-full p-2 text-white text-sm" placeholder="https://…" /></div>' +
+          '<div><label class="block text-xs text-slate-400 mb-1">Link label</label>' +
+          '<input id="ce-banner-link-label" type="text" class="modern-input w-full p-2 text-white text-sm" placeholder="Details" /></div>' +
+        '</div>' +
+        '<button type="button" id="ce-banner-save" class="success-btn text-white px-4 py-2 rounded text-sm w-full">' +
+          '<i class="fas fa-save mr-2"></i>Save banner' +
+        '</button>' +
+        '<div id="ce-banner-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>' +
+
+      '<div class="admin-card rounded-xl p-6" style="grid-column:1/-1;">' +
+        '<div class="flex items-center justify-between mb-3">' +
+          '<h2 class="text-xl font-bold text-white"><i class="fas fa-sticky-note text-yellow-400 mr-2"></i>Staff Notes</h2>' +
+          '<span id="ce-notes-meta" class="text-xs text-slate-500"></span>' +
+        '</div>' +
+        '<p class="text-slate-400 text-xs mb-3">Shared scratchpad for the team — race-day reminders, passwords to rotate, open tasks.</p>' +
+        '<textarea id="ce-staff-notes" rows="5" class="modern-input w-full p-3 text-white text-sm mb-3 resize-y" placeholder="Write notes for other admins…"></textarea>' +
+        '<button type="button" id="ce-notes-save" class="modern-btn text-white px-4 py-2 rounded text-sm">' +
+          '<i class="fas fa-save mr-2"></i>Save notes' +
+        '</button>' +
+        '<div id="ce-notes-status" class="text-xs text-slate-400 mt-2 min-h-[1.2em]"></div>' +
+      '</div>';
+
+    // Make the overview-tools grid span banner+attention on row 1, notes full width
+    mount.style.display = 'grid';
+    mount.style.gridTemplateColumns = 'repeat(auto-fit, minmax(300px, 1fr))';
+    mount.style.gap = '1.5rem';
+
+    document.getElementById('ce-attn-refresh').addEventListener('click', loadAttention);
+    document.getElementById('ce-banner-save').addEventListener('click', saveBanner);
+    document.getElementById('ce-notes-save').addEventListener('click', saveNotes);
+
+    loadAttention();
+    loadBanner();
+    loadNotes();
+  }
+
+  function loadAttention() {
+    var list = document.getElementById('ce-attn-list');
+    var firestore = db();
+    if (!list) return;
+    if (!firestore) {
+      list.innerHTML = '<div class="text-slate-500">Waiting for Firebase…</div>';
+      return setTimeout(loadAttention, 400);
+    }
+    list.innerHTML = '<div class="text-slate-500"><i class="fas fa-spinner fa-spin mr-2"></i>Checking queues…</div>';
+
+    var checks = [
+      { label: 'gallery photo(s)', href: '#media', icon: 'fa-images', color: 'text-purple-400',
+        run: function () { return firestore.collection('gallery_images').where('approved', '==', false).get(); } },
+      { label: 'fan wall post(s)', href: '#fanwall', icon: 'fa-bullhorn', color: 'text-orange-400',
+        run: function () { return firestore.collection('fan_wall').where('approved', '==', false).get(); } },
+      { label: 'Q&A item(s)', href: '#qna', icon: 'fa-comments', color: 'text-cyan-400',
+        run: function () { return firestore.collection('qna_submissions').where('status', '==', 'pending').get(); } },
+      { label: 'video(s)', href: '#videos', icon: 'fa-video', color: 'text-pink-400',
+        run: function () { return firestore.collection('jonny_videos').where('approved', '==', false).get(); } },
+      { label: 'failed push(es)', href: 'push-notifications.html', icon: 'fa-exclamation-circle', color: 'text-red-400',
+        run: function () { return firestore.collection('push_notifications').where('status', '==', 'failed').get(); } }
+    ];
+
+    Promise.all(checks.map(function (c) {
+      return c.run().then(function (snap) {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: snap.size };
+      }).catch(function () {
+        return { label: c.label, href: c.href, icon: c.icon, color: c.color, count: null };
+      });
+    })).then(function (rows) {
+      var active = rows.filter(function (r) { return r.count && r.count > 0; });
+      if (!active.length) {
+        list.innerHTML = '<div class="text-green-400 flex items-center gap-2"><i class="fas fa-check-circle"></i> All clear — no pending queues</div>';
+        return;
+      }
+      list.innerHTML = active.map(function (r) {
+        return '<a href="' + esc(r.href) + '" class="flex items-center justify-between bg-slate-800/50 border border-slate-700/40 rounded-lg px-3 py-2 hover:border-slate-500/60 transition">' +
+          '<span class="text-slate-200"><i class="fas ' + r.icon + ' ' + r.color + ' mr-2"></i>' + esc(r.count + ' ' + r.label) + '</span>' +
+          '<i class="fas fa-chevron-right text-slate-500 text-xs"></i></a>';
+      }).join('');
+    });
+  }
+
+  function loadBanner() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadBanner, 400);
+    firestore.doc('config/site_banner').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var en = document.getElementById('ce-banner-enabled');
+      var mt = document.getElementById('ce-banner-maintenance');
+      var lv = document.getElementById('ce-banner-level');
+      var msg = document.getElementById('ce-banner-message');
+      var link = document.getElementById('ce-banner-link');
+      var lab = document.getElementById('ce-banner-link-label');
+      if (en) en.checked = !!d.enabled;
+      if (mt) mt.checked = !!d.maintenanceMode;
+      if (lv) lv.value = d.level === 'urgent' || d.level === 'warn' ? d.level : 'info';
+      if (msg) msg.value = d.message || '';
+      if (link) link.value = d.linkUrl || '';
+      if (lab) lab.value = d.linkLabel || '';
+    }).catch(function (e) {
+      console.warn('[console-enhancements] banner load', e);
+    });
+  }
+
+  function saveBanner() {
+    var firestore = db();
+    var status = document.getElementById('ce-banner-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var payload = {
+      enabled: !!(document.getElementById('ce-banner-enabled') || {}).checked,
+      maintenanceMode: !!(document.getElementById('ce-banner-maintenance') || {}).checked,
+      level: (document.getElementById('ce-banner-level') || {}).value || 'info',
+      message: ((document.getElementById('ce-banner-message') || {}).value || '').trim(),
+      linkUrl: ((document.getElementById('ce-banner-link') || {}).value || '').trim(),
+      linkLabel: ((document.getElementById('ce-banner-link-label') || {}).value || '').trim(),
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    };
+    if (payload.enabled && !payload.message) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Add a message before enabling.'; }
+      return;
+    }
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/site_banner').set(payload, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Banner saved. Public pages pick it up within a few seconds.'; }
+      toast('Site banner saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('site_banner.save', 'config/site_banner', { enabled: payload.enabled, maintenanceMode: payload.maintenanceMode }); } catch (_) {}
+      }
+      var hs = document.getElementById('health-banner-status');
+      var hp = document.getElementById('health-banner-preview');
+      if (hs) hs.textContent = payload.enabled ? (payload.maintenanceMode ? 'Maintenance ON' : 'Banner ON') : 'Off';
+      if (hp) hp.textContent = payload.message ? payload.message.slice(0, 80) : 'No message set';
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save banner', 'error');
+    });
+  }
+
+  function loadNotes() {
+    var firestore = db();
+    if (!firestore) return setTimeout(loadNotes, 400);
+    firestore.doc('config/staff_notes').get().then(function (snap) {
+      var d = snap.exists ? (snap.data() || {}) : {};
+      var ta = document.getElementById('ce-staff-notes');
+      var meta = document.getElementById('ce-notes-meta');
+      if (ta) ta.value = d.notes || '';
+      if (meta) {
+        var when = d.updatedAt && d.updatedAt.toDate ? d.updatedAt.toDate().toLocaleString() : '';
+        meta.textContent = when ? ('Updated ' + when) : '';
+      }
+    }).catch(function (e) {
+      console.warn('[console-enhancements] notes load', e);
+    });
+  }
+
+  function saveNotes() {
+    var firestore = db();
+    var status = document.getElementById('ce-notes-status');
+    if (!firestore) {
+      if (status) status.textContent = 'Firestore not ready';
+      return;
+    }
+    var notes = ((document.getElementById('ce-staff-notes') || {}).value || '');
+    if (status) { status.style.color = '#94a3b8'; status.textContent = 'Saving…'; }
+    firestore.doc('config/staff_notes').set({
+      notes: notes,
+      updatedAt: window.firebase.firestore.FieldValue.serverTimestamp(),
+      updatedBy: (window.firebase.auth && window.firebase.auth().currentUser && window.firebase.auth().currentUser.uid) || null
+    }, { merge: true }).then(function () {
+      if (status) { status.style.color = '#4ade80'; status.textContent = 'Notes saved.'; }
+      var meta = document.getElementById('ce-notes-meta');
+      if (meta) meta.textContent = 'Updated just now';
+      toast('Staff notes saved');
+      if (window.logAdminAction) {
+        try { window.logAdminAction('staff_notes.save', 'config/staff_notes', { length: notes.length }); } catch (_) {}
+      }
+    }).catch(function (e) {
+      if (status) { status.style.color = '#f87171'; status.textContent = 'Save failed: ' + (e.message || e); }
+      toast('Failed to save notes', 'error');
+    });
+  }
+
+  // Prefer auth gate used by other admin modules; fall back to DOM ready.
+  function boot() {
+    if (window.RR && window.RR.adminAuthReady && typeof window.RR.adminAuthReady.then === 'function') {
+      window.RR.adminAuthReady.then(init);
+    } else if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  }
+  boot();
+})();

--- a/ios/RedsRacing/www/assets/js/navigation.js
+++ b/ios/RedsRacing/www/assets/js/navigation.js
@@ -1056,6 +1056,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {

--- a/ios/RedsRacing/www/assets/js/site-banner.js
+++ b/ios/RedsRacing/www/assets/js/site-banner.js
@@ -1,0 +1,97 @@
+/**
+ * Public site banner — reads config/site_banner and shows a top strip.
+ * Fields: enabled, message, level (info|warn|urgent), maintenanceMode, linkUrl, linkLabel
+ */
+(function () {
+  'use strict';
+
+  var STYLE_ID = 'rr-site-banner-style';
+  var BAR_ID = 'rr-site-banner';
+
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    var style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent =
+      '#' + BAR_ID + '{position:relative;z-index:9998;width:100%;padding:.7rem 1rem;text-align:center;font:600 .9rem/1.35 system-ui,sans-serif;}' +
+      '#' + BAR_ID + '[data-level="info"]{background:linear-gradient(90deg,#0f766e,#115e59);color:#ecfeff;}' +
+      '#' + BAR_ID + '[data-level="warn"]{background:linear-gradient(90deg,#b45309,#92400e);color:#fffbeb;}' +
+      '#' + BAR_ID + '[data-level="urgent"]{background:linear-gradient(90deg,#b91c1c,#7f1d1d);color:#fef2f2;}' +
+      '#' + BAR_ID + ' a{color:inherit;text-decoration:underline;margin-left:.5rem;}' +
+      '#' + BAR_ID + ' .rr-banner-close{position:absolute;right:.75rem;top:50%;transform:translateY(-50%);background:transparent;border:0;color:inherit;font-size:1.1rem;cursor:pointer;opacity:.8;}' +
+      'body.rr-maintenance #' + BAR_ID + '{position:sticky;top:0;}';
+    document.head.appendChild(style);
+  }
+
+  function dismissKey(message) {
+    return 'rr_banner_dismiss_' + String(message || '').slice(0, 80);
+  }
+
+  function render(data) {
+    if (!data || !data.enabled || !data.message) return;
+    try {
+      if (!data.maintenanceMode && sessionStorage.getItem(dismissKey(data.message)) === '1') return;
+    } catch (_) {}
+
+    ensureStyle();
+    var existing = document.getElementById(BAR_ID);
+    if (existing) existing.remove();
+
+    var level = data.level === 'urgent' || data.level === 'warn' ? data.level : 'info';
+    var bar = document.createElement('div');
+    bar.id = BAR_ID;
+    bar.setAttribute('data-level', level);
+    bar.setAttribute('role', 'status');
+
+    var html = '<span>' + esc(data.message) + '</span>';
+    if (data.linkUrl) {
+      html += ' <a href="' + esc(data.linkUrl) + '">' + esc(data.linkLabel || 'Learn more') + '</a>';
+    }
+    if (!data.maintenanceMode) {
+      html += '<button type="button" class="rr-banner-close" aria-label="Dismiss">×</button>';
+    }
+    bar.innerHTML = html;
+
+    var closeBtn = bar.querySelector('.rr-banner-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        try { sessionStorage.setItem(dismissKey(data.message), '1'); } catch (_) {}
+        bar.remove();
+      });
+    }
+
+    document.body.insertBefore(bar, document.body.firstChild);
+    if (data.maintenanceMode) {
+      document.body.classList.add('rr-maintenance');
+    }
+  }
+
+  function tryLoad(attempt) {
+    attempt = attempt || 0;
+    try {
+      var path = (window.location.pathname || '').toLowerCase();
+      if (path.indexOf('admin-console') !== -1 || path.indexOf('setup-admin') !== -1) return;
+      var db = window._rrFirestore || (window.firebase && window.firebase.firestore && window.firebase.firestore());
+      if (!db) throw new Error('no db');
+      db.doc('config/site_banner').get().then(function (snap) {
+        if (snap && snap.exists) render(snap.data() || {});
+      }).catch(function () {});
+    } catch (_) {
+      if (attempt < 40) setTimeout(function () { tryLoad(attempt + 1); }, 250);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { tryLoad(0); });
+  } else {
+    tryLoad(0);
+  }
+})();

--- a/ios/RedsRacing/www/index.html
+++ b/ios/RedsRacing/www/index.html
@@ -917,6 +917,7 @@
       <meta name="twitter:image" content="/assets/img/og-default.jpg" />
       <script src="assets/js/page-meta.js" defer></script>
       <script src="assets/js/site-search.js" defer></script>
+      <script src="assets/js/site-banner.js" defer></script>
   </head>
   <body>
     <!-- Animated Background -->

--- a/ios/RedsRacing/www/navigation.js
+++ b/ios/RedsRacing/www/navigation.js
@@ -1057,6 +1057,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {

--- a/navigation.js
+++ b/navigation.js
@@ -1057,6 +1057,17 @@
         document.head.appendChild(ads);
       }
     } catch (_) {}
+
+    // Public site banner / maintenance strip from config/site_banner
+    try {
+      if (!document.getElementById('rr-site-banner-script')) {
+        var banner = document.createElement('script');
+        banner.id = 'rr-site-banner-script';
+        banner.src = 'assets/js/site-banner.js';
+        banner.defer = true;
+        document.head.appendChild(banner);
+      }
+    } catch (_) {}
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Reworks the admin console for day-to-day ops and removes the non-working Android/iOS management UI.

### Removed
- Advanced → **Mobile App Management** (Android/iOS stats, version config, platform push form, crash/analytics stubs)
- Health → Android/iOS version cards and related JS (`refreshAppStats`, version config/distribution helpers, etc.)

### Added / updated
- Overview **Quick Actions** (Inbox, Gallery, Results, Notify, Schedule, Go Live)
- **Needs Attention** digest on Overview (pending gallery / fan wall / Q&A / videos / failed pushes)
- **Site Banner** controls (`config/site_banner`) with maintenance mode
- **Staff Notes** shared pad (`config/staff_notes`)
- Public `assets/js/site-banner.js` loaded from home + navigation chrome
- Health section now shows website version + banner status instead of store apps

Push notifications remain available via the existing Notifications nav link / `push-notifications.html`.

Mobile www bundles were synced for Android/iOS WebView parity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b19851d-2e68-4b03-b786-9947644eb306?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b19851d-2e68-4b03-b786-9947644eb306&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

